### PR TITLE
Prefixed cmake WITH_ definitions with WSREP_LIB_ to avoid collisions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,22 @@ include(CheckIncludeFile)
 include(CTest)
 
 # Options
-option(WITH_AUTO_TEST "Run unit tests automatically after build" ON)
-option(WITH_ASAN "Enable address sanitizer" OFF)
-option(WITH_TSAN "Enable thread sanitizer" OFF)
+
+# Compile unit tests
+option(WSREP_LIB_WITH_UNIT_TESTS "Compile unit tests" ON)
+if (WSREP_LIB_WITH_UNIT_TESTS)
+  # Run tests automatically by default if compiled
+  option(WSREP_LIB_WITH_AUTO_TEST "Run unit tests automatically after build" ON)
+endif()
+
+# Build a sample program
+option(WSREP_LIB_WITH_DBSIM "Compile sample dbsim program" ON)
+
+option(WSREP_LIB_WITH_ASAN "Enable address sanitizer" OFF)
+option(WSREP_LIB_WITH_TSAN "Enable thread sanitizer" OFF)
+
+option(WSREP_LIB_WITH_DOCUMENTATION "Generate documentation" OFF)
+option(WSREP_LIB_WITH_COVERAGE "Compile with coverage instrumentation" OFF)
 
 # CXX flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Weffc++ -Woverloaded-virtual -g")
@@ -20,13 +33,14 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/wsrep-API/v26")
 link_directories("${CMAKE_CURRENT_SOURCE_DIR}/wsrep")
 
-
-find_package(Boost 1.54.0 REQUIRED
-  unit_test_framework
-  program_options
-  filesystem
-  thread
-  )
+if (WSREP_LIB_WITH_UNIT_TESTS OR WSREP_LIB_WITH_DBSIM)
+  find_package(Boost 1.54.0 REQUIRED
+    unit_test_framework
+    program_options
+    filesystem
+    thread
+    )
+endif()
 
 # Coverage
 # To produce a coverage report, call cmake with -DWITH_COVERAGE=ON,
@@ -39,14 +53,14 @@ find_package(Boost 1.54.0 REQUIRED
 #
 # The coverage report output will be in directory root index.html
 #
-if (WITH_COVERAGE)
+if (WSREP_LIB_WITH_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
-if (WITH_ASAN)
+if (WSREP_LIB_WITH_ASAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 endif()
-if (WITH_TSAN)
+if (WSREP_LIB_WITH_TSAN)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
 endif()
 
@@ -55,7 +69,7 @@ add_custom_target(coverage_report
   COMMAND genhtml --output-directory coverage_report lcov.info)
 
 
-if (WITH_DOCUMENTATION)
+if (WSREP_LIB_WITH_DOCUMENTATION)
   find_package(Doxygen REQUIRED)
   add_custom_target(doc ALL
     COMMAND doxygen ${CMAKE_CURRENT_SOURCE_DIR}/doc/Doxyfile
@@ -66,6 +80,10 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(wsrep-API)
-add_subdirectory(test)
-add_subdirectory(dbsim)
+if (WSREP_LIB_WITH_UNIT_TESTS)
+  add_subdirectory(test)
+endif()
+if (WSREP_LIB_WITH_DBSIM)
+  add_subdirectory(dbsim)
+endif()
 

--- a/dbsim/db_high_priority_service.cpp
+++ b/dbsim/db_high_priority_service.cpp
@@ -8,7 +8,7 @@
 
 db::high_priority_service::high_priority_service(
     db::server& server, db::client& client)
-    : wsrep::high_priority_service(server_.server_state())
+    : wsrep::high_priority_service(server.server_state())
     , server_(server)
     , client_(client)
 { }

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -28,6 +28,10 @@ namespace wsrep
         /**
          * Return true if two pahase commit is required for transaction
          * to commit.
+         *
+         * @todo This interface method should be deprecated, 1pc vs 2pc
+         *       will be deduced from transaction states in
+         *       transaction::before_commit() call.
          */
         virtual bool do_2pc() const = 0;
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -433,7 +433,7 @@ int wsrep::transaction::before_commit()
     case wsrep::client_state::m_high_priority:
         assert(certified());
         assert(ordered());
-        if (client_service_.do_2pc() == false)
+        if (state() == s_executing || state() == s_replaying)
         {
             ret = before_prepare(lock) || after_prepare(lock);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_test(NAME wsrep-lib_test
   COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/wsrep-lib_test
   )
 
-if (WITH_AUTO_TEST)
+if (WSREP_LIB_WITH_AUTO_TEST)
   set(UNIT_TEST wsrep-lib_test)
   add_custom_command(
     TARGET ${UNIT_TEST}


### PR DESCRIPTION
with superproject definitions.

Avoid using client_service::do_2pc() in before_commit() to
determine if 2pc is actually happening, will use transaction
states to deduce that. client_service::do_2pc() should be deprecated.

Fixed a compiler warning in db_high_priority_service.cpp.