### PR TITLE
In order to avoid potential deadlocks, release client_state lock when

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -88,6 +88,7 @@
 #include "view.hpp"
 #include "transaction_id.hpp"
 #include "provider.hpp"
+#include "compiler.hpp"
 
 #include <vector>
 #include <string>
@@ -488,7 +489,8 @@ namespace wsrep
             return state(lock);
         }
 
-        enum state state(wsrep::unique_lock<wsrep::mutex>& lock) const
+        enum state state(wsrep::unique_lock<wsrep::mutex>&
+                         lock WSREP_UNUSED) const
         {
             assert(lock.owns_lock());
             return state_;

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -18,8 +18,8 @@
  */
 
 /** @file transaction.hpp */
-#ifndef WSREP_TRANSACTION_CONTEXT_HPP
-#define WSREP_TRANSACTION_CONTEXT_HPP
+#ifndef WSREP_TRANSACTION_HPP
+#define WSREP_TRANSACTION_HPP
 
 #include "provider.hpp"
 #include "server_state.hpp"
@@ -175,7 +175,7 @@ namespace wsrep
         int certify_fragment(wsrep::unique_lock<wsrep::mutex>&);
         int certify_commit(wsrep::unique_lock<wsrep::mutex>&);
         int append_sr_keys_for_commit();
-        void streaming_rollback();
+        void streaming_rollback(wsrep::unique_lock<wsrep::mutex>&);
         void clear_fragments();
         void cleanup();
         void debug_log_state(const char*) const;
@@ -227,4 +227,4 @@ namespace wsrep
 
 }
 
-#endif // WSREP_TRANSACTION_CONTEXT_HPP
+#endif // WSREP_TRANSACTION_HPP

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -314,13 +314,12 @@ int wsrep::client_state::enter_toi(const wsrep::ws_meta& ws_meta)
 
 int wsrep::client_state::leave_toi()
 {
-    int ret;
+    int ret(0);
     if (toi_mode_ == m_local)
     {
         switch (provider().leave_toi(id_))
         {
         case wsrep::provider::success:
-            ret = 0;
             break;
         default:
             assert(0);

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -929,7 +929,8 @@ int wsrep::server_state::desync(wsrep::unique_lock<wsrep::mutex>& lock)
     return ret;
 }
 
-void wsrep::server_state::resync(wsrep::unique_lock<wsrep::mutex>& lock)
+void wsrep::server_state::resync(wsrep::unique_lock<wsrep::mutex>&
+                                 lock WSREP_UNUSED)
 {
     assert(lock.owns_lock());
     assert(desync_count_ > 0);


### PR DESCRIPTION
calling server state methods which may acquire server_state mutex.