### PR TITLE
wsrep::provider::flag::prepare and typos fixes in comments

### DIFF
--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -217,7 +217,8 @@ namespace wsrep
             static const int pa_unsafe = (1 << 4);
             static const int commutative = (1 << 5);
             static const int native = (1 << 6);
-            static const int snapshot = (1 << 7);
+            static const int prepare = (1 << 7);
+            static const int snapshot = (1 << 8);
         };
 
         /**
@@ -376,6 +377,11 @@ namespace wsrep
     static inline bool rolls_back_transaction(int flags)
     {
         return (flags & wsrep::provider::flag::rollback);
+    }
+
+    static inline bool prepares_transaction(int flags)
+    {
+        return (flags & wsrep::provider::flag::prepare);
     }
 
     static inline bool is_toi(int flags)

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -45,9 +45,9 @@
  * Rollback Mode
  * -------------
  *
- * When High Prioity Transaction (HTP) write set is applied, it
- * may be required that the HTP Brute Force Aborts (BFA) locally
- * executing transaction. As HTP must be able to apply all its
+ * When High Priority Transaction (HPT) write set is applied, it
+ * may be required that the HPT Brute Force Aborts (BFA) locally
+ * executing transaction. As HPT must be able to apply all its
  * write sets without interruption, the locally executing transaction
  * must yield immediately, otherwise a transaction processing
  * may stop or even deadlock. Depending on DBMS implementation,
@@ -55,7 +55,7 @@
  * (synchronous mode)  or the rollback may happen later on
  * (asynchronous mode). The Server Context implementation
  * which derives from Server Context base class must provide
- * the base class the rollback mode which server operates on.
+ * the base class for the rollback mode which server operates on.
  *
  * ### Synchronous
  *
@@ -465,11 +465,9 @@ namespace wsrep
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
             return init_initialized_;
         }
+
         /**
-         *
-         */
-        /**
-         * This method will be called by the provider hen
+         * This method will be called by the provider when
          * a remote write set is being applied. It is the responsibility
          * of the caller to set up transaction context and data properly.
          *

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -62,6 +62,8 @@ std::string wsrep::flags_to_string(int flags)
         oss << "isolation | ";
     if (flags & provider::flag::pa_unsafe)
         oss << "pa_unsafe | ";
+    if (flags & provider::flag::prepare)
+        oss << "prepare | ";
     if (flags & provider::flag::snapshot)
         oss << "snapshot | ";
 

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -92,6 +92,7 @@ namespace
     {
         return wsrep::seqno(seqno);
     }
+
     template <typename F, typename T>
     inline uint32_t map_one(const int flags, const F from,
                             const T to)
@@ -102,18 +103,32 @@ namespace
     uint32_t map_flags_to_native(int flags)
     {
         using wsrep::provider;
-        return (map_one(flags, provider::flag::start_transaction,
+        return (map_one(flags,
+                        provider::flag::start_transaction,
                         WSREP_FLAG_TRX_START) |
-                map_one(flags, provider::flag::commit, WSREP_FLAG_TRX_END) |
-                map_one(flags, provider::flag::rollback, WSREP_FLAG_ROLLBACK) |
-                map_one(flags, provider::flag::isolation, WSREP_FLAG_ISOLATION) |
-                map_one(flags, provider::flag::pa_unsafe, WSREP_FLAG_PA_UNSAFE) |
+                map_one(flags,
+                        provider::flag::commit,
+                        WSREP_FLAG_TRX_END) |
+                map_one(flags,
+                        provider::flag::rollback,
+                        WSREP_FLAG_ROLLBACK) |
+                map_one(flags,
+                        provider::flag::isolation,
+                        WSREP_FLAG_ISOLATION) |
+                map_one(flags,
+                        provider::flag::pa_unsafe,
+                        WSREP_FLAG_PA_UNSAFE) |
                 // map_one(flags, provider::flag::commutative, WSREP_FLAG_COMMUTATIVE) |
                 // map_one(flags, provider::flag::native, WSREP_FLAG_NATIVE) |
-                map_one(flags, provider::flag::snapshot, WSREP_FLAG_SNAPSHOT));
+                map_one(flags,
+                        provider::flag::prepare,
+                        WSREP_FLAG_TRX_PREPARE) |
+                map_one(flags,
+                        provider::flag::snapshot,
+                        WSREP_FLAG_SNAPSHOT));
     }
 
-        int map_flags_from_native(uint32_t flags)
+    int map_flags_from_native(uint32_t flags)
     {
         using wsrep::provider;
         return (map_one(flags,
@@ -133,7 +148,12 @@ namespace
                         provider::flag::pa_unsafe) |
                 // map_one(flags, provider::flag::commutative, WSREP_FLAG_COMMUTATIVE) |
                 // map_one(flags, provider::flag::native, WSREP_FLAG_NATIVE) |
-                map_one(flags, WSREP_FLAG_SNAPSHOT, provider::flag::snapshot));
+                map_one(flags,
+                        WSREP_FLAG_TRX_PREPARE,
+                        provider::flag::prepare) |
+                map_one(flags,
+                        WSREP_FLAG_SNAPSHOT,
+                        provider::flag::snapshot));
     }
 
     class mutable_ws_handle


### PR DESCRIPTION
This pull request consists of two commits:

1) Add flag wsrep::provider::flag::prepare
2) Typo fixes in comments in server_state.hpp