### PR TITLE
Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+#
+language: cpp
+
+compiler:
+  - gcc
+# - clang - does not compile yet
+
+# Build type and option combinations
+# env:
+#  - TYPE=Debug ASAN=ON
+#  - TYPE=RelWithDebInfo ASAN=ON
+#  - CC=gcc-5 CXX=g++-5 TYPE=Debug ASAN=ON
+#  - CC=gcc-5 CXX=g++-5 TYPE=RelWithDebInfo ASAN=ON
+
+matrix:
+  include:
+    - os: linux
+      name: "GCC 4.8 Debug"
+      env: MATRIX_EVAL="TYPE=Debug ASAN=ON DBSIM=OFF"
+    - os: linux
+      name: "GCC 4.8 RelWithDebInfo"
+      env: MATRIX_EVAL="TYPE=RelWithDebInfo ASAN=ON DBSIM=OFF"
+    - os: linux
+      name: "GCC 5 Debug"
+      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=Debug ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "GCC 5 RelWithDebInfo"
+      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "GCC 6 Debug"
+      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=Debug ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "GCC 6 RelWithDebInfo"
+      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "GCC 7 Debug"
+      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=Debug ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "GCC 7 RelWithDebInfo"
+      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+      - g++-5
+      - g++-6
+      - g++-7
+      - libboost-test-dev
+      - libboost-program-options-dev
+      - libboost-filesystem-dev
+      - libboost-thread-dev
+
+before_install:
+  - eval ${MATRIX_EVAL}
+
+script:
+  - echo CC=${CC} CXX=${CXX} TYPE=${TYPE} ASAN=${ASAN} DBSIM=${DBSIM}
+  - cmake . -DCMAKE_BUILD_TYPE=${TYPE}
+            -DWSREP_LIB_WITH_UNIT_TESTS:BOOL=ON
+            -DWSREP_LIB_WITH_DBSIM:BOOL=${DBSIM}
+            -DWSREP_LIB_WITH_ASAN:BOOL=${ASAN}
+  - make VERBOSE=1 -j 4
+  - make test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,60 +5,116 @@ compiler:
   - gcc
 # - clang - does not compile yet
 
-# Build type and option combinations
-# env:
-#  - TYPE=Debug ASAN=ON
-#  - TYPE=RelWithDebInfo ASAN=ON
-#  - CC=gcc-5 CXX=g++-5 TYPE=Debug ASAN=ON
-#  - CC=gcc-5 CXX=g++-5 TYPE=RelWithDebInfo ASAN=ON
 
 matrix:
   include:
     - os: linux
       name: "GCC 4.8 Debug"
-      env: MATRIX_EVAL="TYPE=Debug ASAN=ON DBSIM=OFF"
+      addons:
+        apt:
+          packages:
+            - cmake
+            - libboost-test-dev
+      env: MATRIX_EVAL="TYPE=Debug STRICT=OFF ASAN=ON DBSIM=OFF"
     - os: linux
       name: "GCC 4.8 RelWithDebInfo"
-      env: MATRIX_EVAL="TYPE=RelWithDebInfo ASAN=ON DBSIM=OFF"
+      addons:
+        apt:
+          packages:
+            - cmake
+            - libboost-test-dev
+      env: MATRIX_EVAL="TYPE=RelWithDebInfo STRICT=OFF ASAN=ON DBSIM=OFF"
     - os: linux
       name: "GCC 5 Debug"
-      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=Debug ASAN=OFF DBSIM=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=ON"
     - os: linux
       name: "GCC 5 RelWithDebInfo"
-      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-5 CXX=g++-5 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=ON"
     - os: linux
       name: "GCC 6 Debug"
-      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=Debug ASAN=OFF DBSIM=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=ON"
     - os: linux
       name: "GCC 6 RelWithDebInfo"
-      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-6 CXX=g++-6 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=ON"
     - os: linux
       name: "GCC 7 Debug"
-      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=Debug ASAN=OFF DBSIM=ON"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=ON"
     - os: linux
       name: "GCC 7 RelWithDebInfo"
-      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=RelWithDebInfo ASAN=OFF DBSIM=ON"
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - cmake
-      - g++-5
-      - g++-6
-      - g++-7
-      - libboost-test-dev
-      - libboost-program-options-dev
-      - libboost-filesystem-dev
-      - libboost-thread-dev
-
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=ON"
 before_install:
   - eval ${MATRIX_EVAL}
 
 script:
-  - echo CC=${CC} CXX=${CXX} TYPE=${TYPE} ASAN=${ASAN} DBSIM=${DBSIM}
+  - echo CC=${CC} CXX=${CXX} TYPE=${TYPE} STRICT=${STRICT} ASAN=${ASAN} DBSIM=${DBSIM}
   - cmake . -DCMAKE_BUILD_TYPE=${TYPE}
+            -DWSREP_LIB_STRICT_BUILD_FLAGS:BOOL=${STRICT}
             -DWSREP_LIB_WITH_UNIT_TESTS:BOOL=ON
             -DWSREP_LIB_WITH_DBSIM:BOOL=${DBSIM}
             -DWSREP_LIB_WITH_ASAN:BOOL=${ASAN}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,14 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/wsrep-API/v26")
 link_directories("${CMAKE_CURRENT_SOURCE_DIR}/wsrep")
 
-if (WSREP_LIB_WITH_UNIT_TESTS OR WSREP_LIB_WITH_DBSIM)
+if (WSREP_LIB_WITH_UNIT_TESTS)
   find_package(Boost 1.54.0 REQUIRED
     unit_test_framework
+    )
+endif()
+
+if (WSREP_LIB_WITH_DBSIM)
+  find_package(Boost 1.54.0 REQUIRED
     program_options
     filesystem
     thread

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,14 @@ option(WSREP_LIB_WITH_TSAN "Enable thread sanitizer" OFF)
 option(WSREP_LIB_WITH_DOCUMENTATION "Generate documentation" OFF)
 option(WSREP_LIB_WITH_COVERAGE "Compile with coverage instrumentation" OFF)
 
+option(WSREP_LIB_STRICT_BUILD_FLAGS "Compile with strict build flags")
+
 # CXX flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Weffc++ -Woverloaded-virtual -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Woverloaded-virtual -g")
+
+if (WSREP_LIB_STRICT_BUILD_FLAGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")
+endif()
 
 check_include_file("${CMAKE_CURRENT_SOURCE_DIR}/wsrep/wsrep_api.h" HAVE_WSREP_API_HPP)
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -63,22 +63,6 @@ namespace wsrep
             delete storage_service;
         }
 
-        wsrep::client_state* local_client_state() WSREP_OVERRIDE
-        {
-            wsrep::client_state* ret(new wsrep::mock_client(
-                                         server_state_,
-                                         wsrep::client_id(++last_client_id_),
-                                         wsrep::client_state::m_local));
-            ret->open(ret->id());
-            return ret;
-        }
-
-        void release_client_state(wsrep::client_state* client_state)
-            WSREP_OVERRIDE
-        {
-            delete client_state;
-        }
-
         wsrep::high_priority_service* streaming_applier_service(
             wsrep::client_service&)
             WSREP_OVERRIDE


### PR DESCRIPTION
Travis CI build matrix for Debug, RelWithDebInfo builds for GCC 4.8 (Trusty default), 5, 6 and 7.

For each build the sources are first compiled and after test unit tests are run.