### PR TITLE
Relaxed assertion in sr_key_set::insert()

### DIFF
--- a/include/wsrep/sr_key_set.hpp
+++ b/include/wsrep/sr_key_set.hpp
@@ -36,8 +36,8 @@ namespace wsrep
 
         void insert(const wsrep::key& key)
         {
-            assert(key.size() == 3);
-            if (key.size() < 3)
+            assert(key.size() >= 2);
+            if (key.size() < 2)
             {
                 throw wsrep::runtime_error("Invalid key size");
             }


### PR DESCRIPTION
There are some corner cases where keys with two parts are needed
for a transaction. Relaxed the assertion and sanity check so that
at least two key parts are needed for each key which is assigned
to a transaction.