### PR TITLE
Added is_empty() method to transaction class

### DIFF
--- a/include/wsrep/sr_key_set.hpp
+++ b/include/wsrep/sr_key_set.hpp
@@ -51,6 +51,7 @@ namespace wsrep
 
         const branch_type& root() const { return root_; }
         void clear() { root_.clear(); }
+        bool empty() const { return root_.empty(); }
     private:
         branch_type root_;
     };

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -98,6 +98,14 @@ namespace wsrep
             return (streaming_context_.fragments_certified() > 0);
         }
 
+        /**
+         * Return true if transaction has not generated any changes.
+         */
+        bool is_empty() const
+        {
+            return sr_keys_.empty();
+        }
+
         bool pa_unsafe() const { return pa_unsafe_; }
         void pa_unsafe(bool pa_unsafe) { pa_unsafe_ = pa_unsafe; }
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1229,7 +1229,6 @@ int wsrep::transaction::certify_commit(
         append_sr_keys_for_commit();
         flags(flags() | wsrep::provider::flag::pa_unsafe);
     }
-    sr_keys_.clear();
 
     flags(flags() | wsrep::provider::flag::commit);
 
@@ -1462,6 +1461,7 @@ void wsrep::transaction::cleanup()
     flags_ = 0;
     certified_ = false;
     pa_unsafe_ = false;
+    sr_keys_.clear();
     streaming_context_.cleanup();
     client_service_.cleanup_transaction();
     debug_log_state("cleanup_leave");

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -38,6 +38,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_append_key_data,
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
+    BOOST_REQUIRE(tc.is_empty());
     int vals[3] = {1, 2, 3};
     wsrep::key key(wsrep::key::exclusive);
     for (int i(0); i < 3; ++i)
@@ -45,6 +46,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_append_key_data,
         key.append_key_part(&vals[i], sizeof(vals[i]));
     }
     BOOST_REQUIRE(cc.append_key(key) == 0);
+    BOOST_REQUIRE(tc.is_empty() == false);
     wsrep::const_buffer data(&vals[2], sizeof(vals[2]));
     BOOST_REQUIRE(cc.append_data(data) == 0);
     BOOST_REQUIRE(cc.before_commit() == 0);


### PR DESCRIPTION
Method is_empty() can be determined if there have no been changes
to the transaction.