### PR TITLE
User defined logger callback implementation

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -24,3 +24,9 @@
 std::ostream& wsrep::log::os_ = std::cout;
 static wsrep::default_mutex log_mutex_;
 wsrep::mutex& wsrep::log::mutex_ = log_mutex_;
+wsrep::log::logger_fn_type wsrep::log::logger_fn_ = 0;
+
+void wsrep::log::logger_fn(wsrep::log::logger_fn_type logger_fn)
+{
+    logger_fn_ = logger_fn;
+}

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -498,20 +498,19 @@ namespace
         {
         case WSREP_LOG_FATAL:
         case WSREP_LOG_ERROR:
-            wsrep::log_error() << "wsrep-lib: " << msg;
+            wsrep::log_error() << msg;
             break;
         case WSREP_LOG_WARN:
-            wsrep::log_warning() << "wsrep-lib: " <<msg;
+            wsrep::log_warning() << msg;
             break;
         case WSREP_LOG_INFO:
-            wsrep::log_info() << "wsrep-lib: " << msg;
+            wsrep::log_info() <<  msg;
             break;
         case WSREP_LOG_DEBUG:
-            wsrep::log_debug() << "wsrep-lib: " << msg;
+            wsrep::log_debug() << msg;
             break;
         }
     }
-
 }
 
 wsrep::wsrep_provider_v26::wsrep_provider_v26(


### PR DESCRIPTION
Added static wsrep::log::logger_fn() method to allow user to
provide logger callback.