### PR TITLE
Recover current view from state after SST.

### DIFF
--- a/dbsim/db_client.hpp
+++ b/dbsim/db_client.hpp
@@ -59,6 +59,7 @@ namespace db
         { }
         void start();
         wsrep::client_state& client_state() { return client_state_; }
+        wsrep::client_service& client_service() { return client_service_; }
         bool do_2pc() const { return false; }
     private:
         friend class db::server_state;

--- a/dbsim/db_server_service.hpp
+++ b/dbsim/db_server_service.hpp
@@ -48,12 +48,15 @@ namespace db
             override;
         void log_view(wsrep::high_priority_service*,
                       const wsrep::view&) override;
+        wsrep::view get_view(wsrep::client_service&, const wsrep::id&)
+            override;
         void log_state_change(enum wsrep::server_state::state,
                               enum wsrep::server_state::state) override;
         int wait_committing_transactions(int) override;
         void debug_sync(const char*) override;
     private:
         db::server& server_;
+        wsrep::view logged_view_;
     };
 }
 

--- a/dbsim/db_simulator.cpp
+++ b/dbsim/db_simulator.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "db_simulator.hpp"
+#include "db_client.hpp"
 
 #include "wsrep/logger.hpp"
 
@@ -62,7 +63,11 @@ void db::simulator::sst(db::server& server,
                           << server.server_state().name()
                           << " -> " << request;
     }
-    i->second->server_state().sst_received(gtid, 0);
+
+    db::client dummy(*(i->second), wsrep::client_id(-1),
+                     wsrep::client_state::m_local, params());
+
+    i->second->server_state().sst_received(dummy.client_service(), gtid, 0);
     server.server_state().sst_sent(gtid, 0);
 }
 

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -244,7 +244,11 @@ namespace wsrep
             static const int streaming = (1 << 15);
             static const int snapshot = (1 << 16);
             static const int nbo = (1 << 17);
+
+            /** decipher capability bitmask */
+            static std::string str(int);
         };
+
         provider(wsrep::server_state& server_state)
             : server_state_(server_state)
         { }
@@ -328,7 +332,7 @@ namespace wsrep
          * @return Provider status indicating the result of the call.
          */
         virtual std::pair<wsrep::gtid, enum status>
-        causal_read(int timeout) const = 0;
+            causal_read(int timeout) const = 0;
         virtual enum status wait_for_gtid(const wsrep::gtid&, int timeout) const = 0;
         /**
          * Return last committed GTID.

--- a/include/wsrep/server_service.hpp
+++ b/include/wsrep/server_service.hpp
@@ -131,6 +131,17 @@ namespace wsrep
             const wsrep::view& view) = 0;
 
         /**
+         * Recover a cluster view change event.
+         * The method takes own node ID.
+         *
+         * @param client_service Reference to client_service
+         * @param own_id this node ID obtained on connection to cluster
+         */
+        virtual wsrep::view get_view(
+            wsrep::client_service& client_service,
+            const wsrep::id& own_id) = 0;
+
+        /**
          * Log a state change event.
          *
          * Note that this method may be called with server_state

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -103,6 +103,7 @@ namespace wsrep
     class transaction;
     class const_buffer;
     class server_service;
+    class client_service;
 
     /** @class Server Context
      *
@@ -446,9 +447,12 @@ namespace wsrep
          * initialized, the call will shift the state to initializing
          * and will wait until the initialization is complete.
          *
+         * @param client_service
          * @param gtid GTID provided by the SST transfer
+         * @param error code of the SST operation
          */
-        void sst_received(const wsrep::gtid& gtid, int error);
+        void sst_received(wsrep::client_service& cs,
+                          const wsrep::gtid& gtid, int error);
 
         /**
          * This method must be called after the server initialization
@@ -587,7 +591,7 @@ namespace wsrep
         void wait_until_state(wsrep::unique_lock<wsrep::mutex>&, enum state) const;
         // Close SR transcations whose origin is outside of current
         // cluster view.
-        void close_foreign_sr_transactions(
+        void close_orphaned_sr_transactions(
             wsrep::unique_lock<wsrep::mutex>&,
             wsrep::high_priority_service&);
 

--- a/include/wsrep/view.hpp
+++ b/include/wsrep/view.hpp
@@ -97,6 +97,9 @@ namespace wsrep
         wsrep::view::status status() const
         { return status_; }
 
+        ssize_t capabilities() const
+        { return capabilities_; }
+
         ssize_t own_index() const
         { return own_index_; }
 
@@ -111,6 +114,11 @@ namespace wsrep
         {
             return (members_.empty() && own_index_ == -1);
         }
+
+        /**
+         * Return member index in the view
+         */
+        int member_index(const wsrep::id& member_id) const;
 
         void print(std::ostream& os) const;
 

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -49,6 +49,48 @@ wsrep::provider* wsrep::provider::make_provider(
     return 0;
 }
 
+std::string wsrep::provider::capability::str(int caps)
+{
+    std::ostringstream os;
+
+#define WSREP_PRINT_CAPABILITY(cap_value, cap_string) \
+    if (caps & cap_value) {                           \
+        os << cap_string ", ";                        \
+        caps &= ~cap_value;                           \
+    }
+
+    WSREP_PRINT_CAPABILITY(multi_master,         "MULTI-MASTER");
+    WSREP_PRINT_CAPABILITY(certification,        "CERTIFICATION");
+    WSREP_PRINT_CAPABILITY(parallel_applying,    "PARALLEL_APPLYING");
+    WSREP_PRINT_CAPABILITY(transaction_replay,   "REPLAY");
+    WSREP_PRINT_CAPABILITY(isolation,            "ISOLATION");
+    WSREP_PRINT_CAPABILITY(pause,                "PAUSE");
+    WSREP_PRINT_CAPABILITY(causal_reads,         "CAUSAL_READ");
+    WSREP_PRINT_CAPABILITY(causal_transaction,   "CAUSAL_TRX");
+    WSREP_PRINT_CAPABILITY(incremental_writeset, "INCREMENTAL_WS");
+    WSREP_PRINT_CAPABILITY(session_locks,        "SESSION_LOCK");
+    WSREP_PRINT_CAPABILITY(distributed_locks,    "DISTRIBUTED_LOCK");
+    WSREP_PRINT_CAPABILITY(consistency_check,    "CONSISTENCY_CHECK");
+    WSREP_PRINT_CAPABILITY(unordered,            "UNORDERED");
+    WSREP_PRINT_CAPABILITY(annotation,           "ANNOTATION");
+    WSREP_PRINT_CAPABILITY(preordered,           "PREORDERED");
+    WSREP_PRINT_CAPABILITY(streaming,            "STREAMING");
+    WSREP_PRINT_CAPABILITY(snapshot,             "SNAPSHOT");
+    WSREP_PRINT_CAPABILITY(nbo,                  "NBO");
+
+#undef WSREP_PRINT_CAPABILITY
+
+    if (caps)
+    {
+        assert(caps == 0); // to catch missed capabilities
+        os << "UNKNOWN(" << caps << ")  ";
+    }
+
+    std::string ret(os.str());
+    if (ret.size() > 2) ret.erase(ret.size() - 2);
+    return ret;
+}
+
 std::string wsrep::flags_to_string(int flags)
 {
     std::ostringstream oss;


### PR DESCRIPTION
When member joins the group and needs to receive an SST it won't
receive the corresponding menbership view event because the SST
happens after the event and will already include the effects of
all events ordered before it. The view then must be recovered from
the received state.

Minor renames and cleanups.

References codership/wsrep-lib#18