### PR TITLE
Gh21 implicit deps

### DIFF
--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -219,6 +219,7 @@ namespace wsrep
             static const int native = (1 << 6);
             static const int prepare = (1 << 7);
             static const int snapshot = (1 << 8);
+            static const int implicit_deps = (1 << 9);
         };
 
         /**

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -109,6 +109,9 @@ namespace wsrep
         bool pa_unsafe() const { return pa_unsafe_; }
         void pa_unsafe(bool pa_unsafe) { pa_unsafe_ = pa_unsafe; }
 
+        bool implicit_deps() const { return implicit_deps_; }
+        void implicit_deps(bool implicit) { implicit_deps_ = implicit; }
+
         int start_transaction(const wsrep::transaction_id& id);
 
         int start_transaction(const wsrep::ws_handle& ws_handle,
@@ -204,6 +207,7 @@ namespace wsrep
         wsrep::ws_meta ws_meta_;
         int flags_;
         bool pa_unsafe_;
+        bool implicit_deps_;
         bool certified_;
         wsrep::streaming_context streaming_context_;
         wsrep::sr_key_set sr_keys_;

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -108,6 +108,8 @@ std::string wsrep::flags_to_string(int flags)
         oss << "prepare | ";
     if (flags & provider::flag::snapshot)
         oss << "snapshot | ";
+    if (flags & provider::flag::implicit_deps)
+        oss << "implicit_deps | ";
 
     std::string ret(oss.str());
     if (ret.size() > 3) ret.erase(ret.size() - 3);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -110,6 +110,7 @@ wsrep::transaction::transaction(
     , ws_meta_()
     , flags_()
     , pa_unsafe_(false)
+    , implicit_deps_(false)
     , certified_(false)
     , streaming_context_()
     , sr_keys_()
@@ -1061,6 +1062,11 @@ int wsrep::transaction::certify_fragment(
         client_state_.server_state_.start_streaming_client(&client_state_);
     }
 
+    if (implicit_deps())
+    {
+        flags(flags() | wsrep::provider::flag::implicit_deps);
+    }
+
     int ret(0);
     enum wsrep::client_error error(wsrep::e_success);
     enum wsrep::provider::status cert_ret(wsrep::provider::success);
@@ -1239,6 +1245,11 @@ int wsrep::transaction::certify_commit(
     {
         append_sr_keys_for_commit();
         flags(flags() | wsrep::provider::flag::pa_unsafe);
+    }
+
+    if (implicit_deps())
+    {
+        flags(flags() | wsrep::provider::flag::implicit_deps);
     }
 
     flags(flags() | wsrep::provider::flag::commit);
@@ -1472,6 +1483,7 @@ void wsrep::transaction::cleanup()
     flags_ = 0;
     certified_ = false;
     pa_unsafe_ = false;
+    implicit_deps_ = false;
     sr_keys_.clear();
     streaming_context_.cleanup();
     client_service_.cleanup_transaction();

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -125,7 +125,10 @@ namespace
                         WSREP_FLAG_TRX_PREPARE) |
                 map_one(flags,
                         provider::flag::snapshot,
-                        WSREP_FLAG_SNAPSHOT));
+                        WSREP_FLAG_SNAPSHOT) |
+                map_one(flags,
+                        provider::flag::implicit_deps,
+                        WSREP_FLAG_IMPLICIT_DEPS));
     }
 
     int map_flags_from_native(uint32_t flags)
@@ -153,7 +156,10 @@ namespace
                         provider::flag::prepare) |
                 map_one(flags,
                         WSREP_FLAG_SNAPSHOT,
-                        provider::flag::snapshot));
+                        provider::flag::snapshot) |
+                map_one(flags,
+                        WSREP_FLAG_IMPLICIT_DEPS,
+                        provider::flag::implicit_deps));
     }
 
     class mutable_ws_handle

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -419,11 +419,12 @@ namespace
         }
     }
     
-    int encrypt_cb(wsrep_enc_ctx_t*      /*ctx*/,
-                   const wsrep_buf_t*    /*input*/,
-                   void*                 /*output*/,
-                   wsrep_enc_direction_t /*direction*/,
-                   bool                  /*final*/)
+    wsrep_cb_status_t encrypt_cb(void*                 /* app ctx */,
+                                 wsrep_enc_ctx_t*      /*ctx*/,
+                                 const wsrep_buf_t*    /*input*/,
+                                 void*                 /*output*/,
+                                 wsrep_enc_direction_t /*direction*/,
+                                 bool                  /*final*/)
     {
         return WSREP_CB_SUCCESS;
     }


### PR DESCRIPTION
Added support for the IMPLICIT_DEPS flag from wsrep API

The use of this flag is purely optional, so no special changes on the application side are needed.

It also fixes the definition of encryption callback stub and therefore standalone wsrep-lib compilation