### PR TITLE
Refs codership/wsrep-lib#18: Fixup to proper view from SST processing.

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -597,6 +597,9 @@ namespace wsrep
 
         // Close transactions when handling disconnect from the group.
         void close_transactions_at_disconnect(wsrep::high_priority_service&);
+        // Common actions on final view
+        void go_final(wsrep::unique_lock<wsrep::mutex>&,
+                      const wsrep::view&, wsrep::high_priority_service*);
 
         wsrep::mutex& mutex_;
         wsrep::condition_variable& cond_;

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -638,6 +638,7 @@ void wsrep::server_state::go_final(wsrep::unique_lock<wsrep::mutex>& lock,
                                    const wsrep::view& view,
                                    wsrep::high_priority_service* hps)
 {
+    (void)view; // avoid compiler warning "unused parameter 'view'"
     assert(view.final());
     assert(hps);
     if (hps)

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -536,6 +536,7 @@ void wsrep::server_state::sst_received(wsrep::client_service& cs,
     }
 
     current_view_ = v;
+    server_service_.log_view(NULL /* this view is stored already */, v);
 
     if (provider().sst_received(gtid, error))
     {

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -347,9 +347,12 @@ namespace
         assert(app_ctx);
         wsrep::server_state& server_state(
             *reinterpret_cast<wsrep::server_state*>(app_ctx));
-        assert(server_state.id().is_undefined());
         wsrep::view view(view_from_native(*view_info, server_state.id()));
         assert(view.own_index() >= 0);
+        assert(// first connect
+               server_state.id().is_undefined() ||
+               // reconnect to primary component
+               server_state.id() == view.members()[view.own_index()].id());
         try
         {
             server_state.on_connect(view);


### PR DESCRIPTION
Added a call to log_view() inside on_connect() to do the internal initializations that
need to be done on receiving a new view. Note however that it is not
a view *event*. Here we only need to configure the application to
comply with a new state that it has received, so that it can go on
to apply replication events and catch up with the cluster.