### PR TITLE
codership/wsrep-lib#23 before_command() wait for ongoing rollbacks leaks

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -37,6 +37,7 @@ void wsrep::client_state::open(wsrep::client_id id)
     debug_log_state("open: enter");
     owning_thread_id_ = wsrep::this_thread::get_id();
     current_thread_id_ = owning_thread_id_;
+    has_rollbacker_ = false;
     state(lock, s_idle);
     id_ = id;
     debug_log_state("open: leave");
@@ -86,7 +87,10 @@ int wsrep::client_state::before_command()
     if (transaction_.active() &&
         server_state_.rollback_mode() == wsrep::server_state::rm_sync)
     {
-        while (transaction_.state() == wsrep::transaction::s_aborting)
+        /*
+         * has_rollbacker() returns false, when background rollback is over
+         */
+        while (has_rollbacker())
         {
             cond_.wait(lock);
         }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -918,6 +918,8 @@ bool wsrep::transaction::bf_abort(
             // between releasing the lock and before background
             // rollbacker gets control.
             state(lock, wsrep::transaction::s_aborting);
+            client_state_.set_rollbacker(true);
+
             if (client_state_.mode() == wsrep::client_state::m_high_priority)
             {
                 lock.unlock();

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -43,5 +43,4 @@ namespace wsrep_test
     void bf_abort_provider(wsrep::mock_server_state& sc,
                            const wsrep::transaction& tc,
                            wsrep::seqno bf_seqno);
-
 }

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -899,6 +899,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
     BOOST_REQUIRE(tc.active() == true);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
+    cc.sync_rollback_complete();
     BOOST_REQUIRE(cc.before_command() == 1);
     BOOST_REQUIRE(tc.active() == false);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
@@ -923,6 +924,7 @@ BOOST_FIXTURE_TEST_CASE(
     wsrep_test::bf_abort_unordered(cc);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
     BOOST_REQUIRE(tc.active());
+    cc.sync_rollback_complete();
     BOOST_REQUIRE(cc.before_command() == 1);
     BOOST_REQUIRE(tc.active() == false);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);


### PR DESCRIPTION
Storing background rollbacker thread's ID in client state.
Tis can be used for detecting if there is ongoing background rollback,
and client should keep waiting in before_command() entry to avoid conflicts
in accessing client state during background rollbacking.

There is new public method for client_state: prepare_for_background_rollback()
Background rollbacker thread should call this, before backround rollbacking
starts, to assign himself as the rollbacker for the client.

sync_rollback_complete() method has been modified to release the backround
rollbacker thread from client_state