### PR TITLE
Refs codership/wsrep-lib#18 Don't recover view from state if SST failed.

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -480,14 +480,18 @@ int wsrep::server_state::start_sst(const std::string& sst_request,
 
 void wsrep::server_state::sst_sent(const wsrep::gtid& gtid, int error)
 {
-    wsrep::log_info() << "SST sent: " << gtid << ": " << error;
+    if (0 == error)
+        wsrep::log_info() << "SST sent: " << gtid;
+    else
+        wsrep::log_info() << "SST sending failed: " << error;
+
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
     state(lock, s_joined);
     lock.unlock();
     if (provider_->sst_sent(gtid, error))
     {
         server_service_.log_message(wsrep::log::warning,
-                                    "SST sent returned an error");
+                                    "Provider sst_sent() returned an error");
     }
 }
 


### PR DESCRIPTION
It is pointless and most likely will result in an unnecessary error message logged.

MTR: https://jenkins.galeracluster.com:8443/view/mtr/job/mtr-galera-4.x-mariadb-10.4/94/