### PR TITLE
Lost e_error_during_commit if fragment size exceeds maximum size

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -224,7 +224,13 @@ int wsrep::client_state::after_statement()
         client_service_.bf_rollback();
         lock.lock();
         assert(transaction_.state() == wsrep::transaction::s_aborted);
-        override_error(wsrep::e_deadlock_error);
+        // Error may be set already. For example, if fragment size
+        // exceeded the maximum size in certify_fragment(), then
+        // we already have wsrep::e_error_during_commit
+        if (current_error() == wsrep::e_success)
+        {
+            override_error(wsrep::e_deadlock_error);
+        }
     }
     lock.unlock();
 


### PR DESCRIPTION
If the size of a SR fragment exceeds the maximum size that the
replication provider allows us to replicate, then we are expected to
set the client error code to e_error_during_commit.
However, client_state::after_statement() unconditionally overrides it
to error e_deadlock_error.
Fixes client_state::after_statement() so that it overrided the error
only if noerror has been set yet.