### PR TITLE
codership/wsrep-lib#32 Allow transient desync errors in desync_and_pa…

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -562,6 +562,7 @@ namespace wsrep
             , init_synced_()
             , sst_gtid_()
             , desync_count_()
+            , desynced_on_pause_()
             , pause_count_()
             , pause_seqno_()
             , streaming_clients_()
@@ -613,6 +614,9 @@ namespace wsrep
         bool init_synced_;
         wsrep::gtid sst_gtid_;
         size_t desync_count_;
+        // Boolean to denote if desync was succesfull when desyncing
+        // and pausing the provider on one go.
+        bool desynced_on_pause_;
         size_t pause_count_;
         wsrep::seqno pause_seqno_;
         typedef std::map<wsrep::client_id, wsrep::client_state*>


### PR DESCRIPTION
…use()

Provider desync may return an error if the provider cannot communicate
with rest of the cluster. However, this is acceptable for example
if the node has dropped from primary view. Instead of returning
error immediately after failed desync(), attempt to pause the provider
regardless of the error. If pause operation fails, error is returned.
In order to avoid resync in resume_and_resync() in the case desync
failed in desync_and_pause(), new member variable desynced_on_pause_
was introduced to decide whether to resync or not in resume_and_resync().
This variable is protected by pause()/resume() calls since they do
not allow concurrent pause/resume operations.