### PR TITLE
Improvements to server state management

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -609,6 +609,12 @@ namespace wsrep
         // Close transactions when handling disconnect from the group.
         void close_transactions_at_disconnect(wsrep::high_priority_service&);
 
+        // Handle primary view
+        void on_primary_view(const wsrep::view&,
+                             wsrep::high_priority_service*);
+        // Handle non-primary view
+        void on_non_primary_view(const wsrep::view&,
+                                 wsrep::high_priority_service*);
         // Common actions on final view
         void go_final(wsrep::unique_lock<wsrep::mutex>&,
                       const wsrep::view&, wsrep::high_priority_service*);

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -286,6 +286,16 @@ namespace wsrep
             return *provider_;
         }
 
+        /**
+         * Initialize connection to cluster.
+         *
+         * @param cluster_name A string containing the name of the cluster
+         * @param cluster_address Cluster address string
+         * @param state_donor String containing a list of desired donors
+         * @param bootstrap Bootstrap option
+         *
+         * @return Zero in case of success, non-zero on error.
+         */
         int connect(const std::string& cluster_name,
                     const std::string& cluster_address,
                     const std::string& state_donor,
@@ -598,6 +608,7 @@ namespace wsrep
 
         // Close transactions when handling disconnect from the group.
         void close_transactions_at_disconnect(wsrep::high_priority_service&);
+
         // Common actions on final view
         void go_final(wsrep::unique_lock<wsrep::mutex>&,
                       const wsrep::view&, wsrep::high_priority_service*);

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -600,6 +600,8 @@ namespace wsrep
         void resync(wsrep::unique_lock<wsrep::mutex>&);
         void state(wsrep::unique_lock<wsrep::mutex>&, enum state);
         void wait_until_state(wsrep::unique_lock<wsrep::mutex>&, enum state) const;
+        // Interrupt all threads which are waiting for state
+        void interrupt_state_waiters(wsrep::unique_lock<wsrep::mutex>&);
         // Close SR transcations whose origin is outside of current
         // cluster view.
         void close_orphaned_sr_transactions(

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -117,7 +117,7 @@ namespace wsrep
          *
          * @todo Fix UML generation
          *
-         * Server state diagram if the sst_before_init() returns false.
+         * Server state diagram if initialization happens before SST.
          *
          * [*] --> disconnected
          * disconnected --> initializing
@@ -129,7 +129,7 @@ namespace wsrep
          * synced --> donor
          * donor --> joined
          *
-         * Server state diagram if the sst_before_init() returns true.
+         * Server state diagram if SST happens before initialization.
          *
          * [*] --> disconnected
          * disconnected --> connected

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -691,7 +691,7 @@ void wsrep::server_state::on_primary_view(
             state(lock, s_initializing);
             if (init_initialized_)
             {
-                // If storage engines have already been initialized,
+                // If server side has already been initialized,
                 // skip directly to s_joined.
                 state(lock, s_initialized);
                 state(lock, s_joined);
@@ -709,6 +709,12 @@ void wsrep::server_state::on_primary_view(
         if (state_ == s_connected)
         {
             state(lock, s_joiner);
+        }
+        if (init_initialized_)
+        {
+            // If server side has already been initialized,
+            // skip directly to s_joined.
+            state(lock, s_joined);
         }
     }
 

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -377,7 +377,7 @@ wsrep::server_state::~server_state()
 std::vector<wsrep::provider::status_variable>
 wsrep::server_state::status() const
 {
-    return provider_->status();
+    return provider().status();
 }
 
 
@@ -394,7 +394,7 @@ wsrep::seqno wsrep::server_state::pause()
     ++pause_count_;
     assert(pause_seqno_.is_undefined());
     lock.unlock();
-    pause_seqno_ = provider_->pause();
+    pause_seqno_ = provider().pause();
     lock.lock();
     if (pause_seqno_.is_undefined())
     {
@@ -409,7 +409,7 @@ void wsrep::server_state::resume()
     wsrep::log_info() << "resume";
     assert(pause_seqno_.is_undefined() == false);
     assert(pause_count_ == 1);
-    if (provider_->resume())
+    if (provider().resume())
     {
         throw wsrep::runtime_error("Failed to resume provider");
     }
@@ -512,7 +512,7 @@ void wsrep::server_state::sst_sent(const wsrep::gtid& gtid, int error)
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
     state(lock, s_joined);
     lock.unlock();
-    if (provider_->sst_sent(gtid, error))
+    if (provider().sst_sent(gtid, error))
     {
         server_service_.log_message(wsrep::log::warning,
                                     "Provider sst_sent() returned an error");
@@ -624,13 +624,13 @@ enum wsrep::provider::status
 wsrep::server_state::wait_for_gtid(const wsrep::gtid& gtid, int timeout)
     const
 {
-    return provider_->wait_for_gtid(gtid, timeout);
+    return provider().wait_for_gtid(gtid, timeout);
 }
 
 std::pair<wsrep::gtid, enum wsrep::provider::status>
 wsrep::server_state::causal_read(int timeout) const
 {
-    return provider_->causal_read(timeout);
+    return provider().causal_read(timeout);
 }
 
 void wsrep::server_state::on_connect(const wsrep::view& view)
@@ -1045,7 +1045,7 @@ int wsrep::server_state::desync(wsrep::unique_lock<wsrep::mutex>& lock)
     assert(lock.owns_lock());
     ++desync_count_;
     lock.unlock();
-    int ret(provider_->desync());
+    int ret(provider().desync());
     lock.lock();
     if (ret)
     {
@@ -1062,7 +1062,7 @@ void wsrep::server_state::resync(wsrep::unique_lock<wsrep::mutex>&
     if (desync_count_ > 0)
     {
         --desync_count_;
-        if (provider_->resync())
+        if (provider().resync())
         {
             throw wsrep::runtime_error("Failed to resync");
         }

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -531,6 +531,9 @@ void wsrep::server_state::sst_received(wsrep::client_service& cs,
         if (init_initialized_ == false)
         {
             state(lock, s_initializing);
+            lock.unlock();
+            server_service_.debug_sync("on_view_wait_initialized");
+            lock.lock();
             wait_until_state(lock, s_initialized);
             assert(init_initialized_);
         }
@@ -1072,7 +1075,7 @@ void wsrep::server_state::state(
             {  0,   1,   0,    1,    0,   0,   0,   0,   0}, /* dis */
             {  1,   0,   1,    0,    0,   0,   0,   0,   0}, /* ing */
             {  1,   0,   0,    1,    0,   1,   0,   0,   0}, /* ized */
-            {  1,   0,   0,    1,    1,   0,   0,   1,   0}, /* cted */
+            {  1,   0,   0,    1,    1,   0,   0,   1,   1}, /* cted */
             {  1,   1,   0,    0,    0,   1,   0,   0,   0}, /* jer */
             {  1,   0,   0,    1,    0,   0,   0,   1,   1}, /* jed */
             {  1,   0,   0,    0,    0,   1,   0,   0,   1}, /* dor */

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -681,7 +681,7 @@ void wsrep::server_state::on_connect(const wsrep::view& view)
 }
 
 void wsrep::server_state::on_primary_view(
-    const wsrep::view& view,
+    const wsrep::view& view WSREP_UNUSED,
     wsrep::high_priority_service* high_priority_service)
 {
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -686,6 +686,7 @@ void wsrep::server_state::on_view(const wsrep::view& view,
     wsrep::log_info()
         << "================================================\nView:\n"
         << "  id: " << view.state_id() << "\n"
+        << "  seqno: " << view.view_seqno() << "\n"
         << "  status: " << view.status() << "\n"
         << "  prococol_version: " << view.protocol_version() << "\n"
         << "  own_index: " << view.own_index() << "\n"
@@ -722,6 +723,13 @@ void wsrep::server_state::on_view(const wsrep::view& view,
             {
                 state(lock, s_joiner);
                 state(lock, s_initializing);
+                if (init_initialized_)
+                {
+                    // If storage engines have already been initialized,
+                    // skip directly to s_joined.
+                    state(lock, s_initialized);
+                    state(lock, s_joined);
+                }
             }
             else if (state_ == s_joiner)
             {

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -724,7 +724,7 @@ void wsrep::server_state::on_primary_view(
         {
             state(lock, s_joiner);
         }
-        if (init_initialized_)
+        if (init_initialized_ && state_ != s_joined)
         {
             // If server side has already been initialized,
             // skip directly to s_joined.

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -364,7 +364,7 @@ namespace
         }
         catch (const wsrep::runtime_error& e)
         {
-            std::cerr << "Exception: " << e.what();
+            wsrep::log_error() << "Exception: " << e.what();
             return WSREP_CB_FAILURE;
         }
     }
@@ -389,7 +389,7 @@ namespace
         }
         catch (const wsrep::runtime_error& e)
         {
-            std::cerr << "Exception: " << e.what();
+            wsrep::log_error() << "Exception: " << e.what();
             return WSREP_CB_FAILURE;
         }
     }

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -186,6 +186,10 @@ namespace wsrep
         } sync_point_action_;
         bool sst_before_init_;
 
+        void logged_view(const wsrep::view& view)
+        {
+            logged_view_ = view;
+        }
     private:
         wsrep::server_state& server_state_;
         unsigned long long last_client_id_;

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -172,8 +172,13 @@ namespace wsrep
             {
                 switch (sync_point_action_)
                 {
+                case spa_none:
+                    break;
                 case spa_initialize:
                     server_state_.initialized();
+                    break;
+                case spa_initialize_error:
+                    throw wsrep::runtime_error("Inject initialization error");
                     break;
                 }
             }
@@ -182,7 +187,10 @@ namespace wsrep
         std::string sync_point_enabled_;
         enum sync_point_action
         {
-            spa_initialize
+            spa_none,
+            spa_initialize,
+            spa_initialize_error
+
         } sync_point_action_;
         bool sst_before_init_;
 

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -371,7 +371,7 @@ BOOST_FIXTURE_TEST_CASE(
     disconnect();
 }
 
-// Error during SST.q
+// Error during SST.
 BOOST_FIXTURE_TEST_CASE(
     server_state_sst_first_error_on_joiner,
     sst_first_server_fixture)
@@ -379,6 +379,9 @@ BOOST_FIXTURE_TEST_CASE(
     connect_in_view(second_view);
     ss.prepare_for_sst();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joiner);
+    ss.sst_received(cc, wsrep::gtid(wsrep::id::undefined(),
+                                    wsrep::seqno::undefined()), 1);
+    disconnect();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -481,3 +481,35 @@ BOOST_FIXTURE_TEST_CASE(
     ss.on_sync();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
 }
+
+/////////////////////////////////////////////////////////////////////////////
+//                          Donor state transitions                        //
+/////////////////////////////////////////////////////////////////////////////
+
+BOOST_FIXTURE_TEST_CASE(
+    server_state_sst_first_donate_success,
+    sst_first_server_fixture)
+{
+    bootstrap();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+    ss.start_sst("", wsrep::gtid(cluster_id, wsrep::seqno(2)), false);
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_donor);
+    ss.sst_sent(wsrep::gtid(cluster_id, wsrep::seqno(2)), 0);
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joined);
+    ss.on_sync();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+}
+
+BOOST_FIXTURE_TEST_CASE(
+    server_state_sst_first_donate_error,
+    sst_first_server_fixture)
+{
+    bootstrap();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+    ss.start_sst("", wsrep::gtid(cluster_id, wsrep::seqno(2)), false);
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_donor);
+    ss.sst_sent(wsrep::gtid(cluster_id, wsrep::seqno(2)), 1);
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joined);
+    ss.on_sync();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+}

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -513,3 +513,19 @@ BOOST_FIXTURE_TEST_CASE(
     ss.on_sync();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
 }
+
+/////////////////////////////////////////////////////////////////////////////
+//                    Pause/Resume and Desync/Resync                       //
+/////////////////////////////////////////////////////////////////////////////
+
+BOOST_FIXTURE_TEST_CASE(
+    server_state_sst_first_desync_and_pause_resync_and_resume,
+    sst_first_server_fixture)
+{
+    bootstrap();
+    ss.desync_and_pause();
+    // @todo: Should we have here different state than synced
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+    ss.resume_and_resync();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);
+}


### PR DESCRIPTION
codership/wsrep-lib#34 Improvements to server state management

This PR consists of several fixes to `server_state` handling in error situations and IST:
* Allowed state change to disconnecting from all states except disconnecting and disconnected
* Fixed a state change assertion in case where IST view event was handled (init first scenario)
* Provided a method to interrupt state waiters in case of error situations

Refactoring:
* Split primary and non-primary view handling in separate methods to improve readability
* Refactored server context fixtures to allow easy testing for more complicated scenarios

Provided more unit test coverage for server state change scenarios.

