### PR TITLE
Compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 cmake_minimum_required (VERSION 2.8)
 project (wsrep-lib)
 include(CheckIncludeFile)
+include(CheckCXXCompilerFlag)
 
 # Options
 
@@ -28,6 +29,11 @@ option(WSREP_LIB_STRICT_BUILD_FLAGS "Compile with strict build flags")
 
 # CXX flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Woverloaded-virtual -g")
+
+CHECK_CXX_COMPILER_FLAG("-Wimplicit-fallthrough" COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH)
+if (COMPILER_SUPPORTS_IMPLICIT_FALLTHROUGH)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough")
+endif()
 
 if (WSREP_LIB_STRICT_BUILD_FLAGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weffc++")

--- a/include/wsrep/compiler.hpp
+++ b/include/wsrep/compiler.hpp
@@ -29,3 +29,11 @@
 #else
 #define WSREP_OVERRIDE
 #endif // __cplusplus >= 201103L
+
+#if defined(__clang__) && __cplusplus >= 201103L
+#define WSREP_FALLTHROUGH [[clang::fallthrough]]
+#elif (defined(__GNUC__) || defined(__GNUG__)) && (__GNUC__ >= 7)
+#define WSREP_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define WSREP_FALLTHROUGH
+#endif

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -875,7 +875,7 @@ void wsrep::server_state::on_sync()
             break;
         case s_connected:
             state(lock, s_joiner);
-            // fall through
+           WSREP_FALLTHROUGH;
         case s_joiner:
             state(lock, s_initializing);
             break;
@@ -885,7 +885,7 @@ void wsrep::server_state::on_sync()
             break;
         case s_initialized:
             state(lock, s_joined);
-            // fall through
+            WSREP_FALLTHROUGH;
         default:
             /* State */
             state(lock, s_synced);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -551,7 +551,7 @@ int wsrep::transaction::before_rollback()
         case s_preparing:
             // Error detected during prepare phase
             state(lock, s_must_abort);
-            // fall through
+            WSREP_FALLTHROUGH;
         case s_executing:
             // Voluntary rollback
             if (is_streaming())
@@ -697,7 +697,7 @@ int wsrep::transaction::after_statement()
             break;
         }
         // Continue to replay if rollback() changed the state to s_must_replay
-        // Fall through
+        WSREP_FALLTHROUGH;
     case s_must_replay:
     {
         state(lock, s_replaying);


### PR DESCRIPTION
Compilation is failing due unused private ws_meta_ object.
Added -Wimplicit-fallthrough and WSREP_FALLTHROUGH macro.