### PR TITLE
codership/wsrep-lib#44 Provider name, version and vendor getters

### DIFF
--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -347,6 +347,26 @@ namespace wsrep
 
         virtual std::string options() const = 0;
         virtual enum status options(const std::string&) = 0;
+        /**
+         * Get provider name.
+         *
+         * @return Provider name string.
+         */
+        virtual std::string name() const = 0;
+
+        /**
+         * Get provider version.
+         *
+         * @return Provider version string.
+         */
+        virtual std::string version() const = 0;
+
+        /**
+         * Get provider vendor.
+         *
+         * @return Provider vendor string.
+         */
+        virtual std::string vendor() const = 0;
 
         /**
          * Return pointer to native provider handle.

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -925,6 +925,21 @@ wsrep::wsrep_provider_v26::options(const std::string& opts)
     return map_return_value(wsrep_->options_set(wsrep_, opts.c_str()));
 }
 
+std::string wsrep::wsrep_provider_v26::name() const
+{
+    return (wsrep_->provider_name ? wsrep_->provider_name : "unknown");
+}
+
+std::string wsrep::wsrep_provider_v26::version() const
+{
+    return (wsrep_->provider_version ? wsrep_->provider_version : "unknown");
+}
+
+std::string wsrep::wsrep_provider_v26::vendor() const
+{
+    return (wsrep_->provider_vendor ? wsrep_->provider_vendor : "unknown");
+}
+
 void* wsrep::wsrep_provider_v26::native() const
 {
     return wsrep_;

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -83,6 +83,9 @@ namespace wsrep
         void reset_status();
         std::string options() const;
         enum wsrep::provider::status options(const std::string&);
+        std::string name() const;
+        std::string version() const;
+        std::string vendor() const;
         void* native() const;
     private:
         wsrep_provider_v26(const wsrep_provider_v26&);

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -248,6 +248,9 @@ namespace wsrep
         std::string options() const { return ""; }
         enum wsrep::provider::status options(const std::string&)
         { return wsrep::provider::success; }
+        std::string name() const WSREP_OVERRIDE { return "mock"; }
+        std::string version() const WSREP_OVERRIDE { return "0.0"; }
+        std::string vendor() const WSREP_OVERRIDE { return "mock"; }
         void* native() const { return 0; }
 
         //


### PR DESCRIPTION
Added methods to get provider name, version and vendor strings
into wsrep::provider interface. Implementations for v26 and mock
providers.