### PR TITLE
Fix excessive messages / warnings

### DIFF
--- a/include/wsrep/streaming_context.hpp
+++ b/include/wsrep/streaming_context.hpp
@@ -50,8 +50,8 @@ namespace wsrep
 
         void enable(enum fragment_unit fragment_unit, size_t fragment_size)
         {
-            wsrep::log_info() << "Enabling streaming: "
-                              << fragment_unit << " " << fragment_size;
+            wsrep::log_debug() << "Enabling streaming: "
+                               << fragment_unit << " " << fragment_size;
             assert(fragment_size > 0);
             fragment_unit_ = fragment_unit;
             fragment_size_ = fragment_size;
@@ -63,7 +63,7 @@ namespace wsrep
 
         void disable()
         {
-            wsrep::log_info() << "Disabling streaming";
+            wsrep::log_debug() << "Disabling streaming";
             fragment_size_ = 0;
         }
 

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -160,12 +160,15 @@ static int apply_write_set(wsrep::server_state& server_state,
                     ws_meta.server_id(), ws_meta.transaction_id()));
             if (sa == 0)
             {
-                // It is possible that rapid group membership changes
-                // may cause streaming transaction be rolled back before
-                // commit fragment comes in. Although this is a valid
-                // situation, log a warning if a sac cannot be found as
-                // it may be an indication of  a bug too.
-                wsrep::log_warning()
+                // It is a known limitation that galera provider
+                // cannot always determine if certification test
+                // for interrupted transaction will pass or fail
+                // (see comments in transaction::certify_fragment()).
+                // As a consequence, unnecessary rollback fragments
+                // may be delivered here. The message below has
+                // been intentionally turned into a debug message,
+                // rather than warning.
+                wsrep::log_debug()
                     << "Could not find applier context for "
                     << ws_meta.server_id()
                     << ": " << ws_meta.transaction_id();


### PR DESCRIPTION
Two commits to avoid excessive messages / warnings:
- "Could not find applier context" warning for rollback fragment
- Change "Enable streaming" and "Disable streaming" info messages to debug
