### PR TITLE
Transition on primary view for logical SST methods

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -777,13 +777,9 @@ void wsrep::server_state::on_primary_view(
     }
     else
     {
-        if (state_ == s_joiner)
+        if (state_ == s_initialized)
         {
             state(lock, s_joined);
-            if (init_synced_)
-            {
-                state(lock, s_synced);
-            }
         }
     }
 }


### PR DESCRIPTION
When mysqldump is used as SST method and initialization hasn't been done we will not transition to s_joined state. Later when synced_cb is called we would not be in correct state for transition.