### PR TITLE
Fix static initialization issues and clang compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,4 @@
-#
 language: cpp
-
-compiler:
-  - gcc
-# - clang - does not compile yet
-
 
 matrix:
   include:
@@ -108,6 +102,129 @@ matrix:
             - libboost-filesystem-dev
             - libboost-thread-dev
       env: MATRIX_EVAL="CC=gcc-7 CXX=g++-7 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "Clang 3.6 Debug"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-3.6 CXX=clang++-3.6 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "Clang 3.6 RelWithDebInfo"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-3.6 CXX=clang++-3.6 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=ON"
+    - os: linux
+      name: "Clang 4.0 Debug"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-4.0 CXX=clang++-4.0 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=OFF"
+    - os: linux
+      name: "Clang 4.0 RelWithDebInfo"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-4.0 CXX=clang++-4.0 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=OFF"
+    - os: linux
+      name: "Clang 5.0 Debug"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-5.0 CXX=clang++-5.0 TYPE=Debug STRICT=ON ASAN=OFF DBSIM=OFF"
+    - os: linux
+      name: "Clang 5.0 RelWithDebInfo"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang-5.0 CXX=clang++-5.0 TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=OFF"
+    - os: linux
+      dist: xenial
+      name: "Clang 7.0 Debug"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-7.0
+          packages:
+            - clang
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang CXX=clang++ TYPE=Debug STRICT=ON ASAN=OFF DBSIM=OFF"
+    - os: linux
+      dist: xenial
+      name: "Clang 7.0 RelWithDebInfo"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-xenial-7.0
+          packages:
+            - clang
+            - cmake
+            - libboost-test-dev
+            - libboost-program-options-dev
+            - libboost-filesystem-dev
+            - libboost-thread-dev
+      env: MATRIX_EVAL="CC=clang CXX=clang++ TYPE=RelWithDebInfo STRICT=ON ASAN=OFF DBSIM=OFF"
+
 before_install:
   - eval ${MATRIX_EVAL}
 

--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -60,7 +60,7 @@ namespace db
         enum wsrep::provider::status replay()
             override;
 
-        void emergency_shutdown() { ::abort(); }
+        void emergency_shutdown() override { ::abort(); }
         void debug_sync(const char*) override { }
         void debug_crash(const char*) override { }
     private:

--- a/dbsim/db_server.cpp
+++ b/dbsim/db_server.cpp
@@ -33,7 +33,7 @@ db::server::server(simulator& simulator,
     , mutex_()
     , cond_()
     , server_service_(*this)
-    , server_state_(*this, server_service_,
+    , server_state_(server_service_,
                     name, address, "dbsim_" + name + "_data")
     , last_client_id_(0)
     , last_transaction_id_(0)

--- a/dbsim/db_server_service.hpp
+++ b/dbsim/db_server_service.hpp
@@ -43,7 +43,7 @@ namespace db
         std::string sst_request() override;
         void background_rollback(wsrep::client_state&) override;
         void bootstrap() override;
-        void log_message(enum wsrep::log::level, const char* message);
+        void log_message(enum wsrep::log::level, const char* message) override;
         void log_dummy_write_set(wsrep::client_state&, const wsrep::ws_meta&)
             override;
         void log_view(wsrep::high_priority_service*,

--- a/dbsim/db_server_state.hpp
+++ b/dbsim/db_server_state.hpp
@@ -32,8 +32,7 @@ namespace db
     class server_state : public wsrep::server_state
     {
     public:
-        server_state(db::server& server,
-                     wsrep::server_service& server_service,
+        server_state(wsrep::server_service& server_service,
                      const std::string& name,
                      const std::string& address,
                      const std::string& working_dir)
@@ -50,12 +49,10 @@ namespace db
                 wsrep::server_state::rm_async)
             , mutex_()
             , cond_()
-            , server_(server)
         { }
     private:
         wsrep::default_mutex mutex_;
         wsrep::default_condition_variable cond_;
-        db::server& server_;
     };
 }
 

--- a/include/wsrep/gtid.hpp
+++ b/include/wsrep/gtid.hpp
@@ -31,8 +31,8 @@ namespace wsrep
     {
     public:
         gtid()
-            : id_(wsrep::id::undefined())
-            , seqno_(wsrep::seqno::undefined())
+            : id_()
+            , seqno_()
         { }
         gtid(const wsrep::id& id, wsrep::seqno seqno)
             : id_(id)
@@ -44,13 +44,12 @@ namespace wsrep
         {
             return (seqno_.is_undefined() && id_.is_undefined());
         }
-        static wsrep::gtid undefined()
+        static const wsrep::gtid& undefined()
         {
-            static const wsrep::gtid ret(wsrep::id::undefined(),
-                                         wsrep::seqno::undefined());
-            return ret;
+            return undefined_;
         }
     private:
+        static const wsrep::gtid undefined_;
         wsrep::id id_;
         wsrep::seqno seqno_;
     };

--- a/include/wsrep/id.hpp
+++ b/include/wsrep/id.hpp
@@ -90,10 +90,10 @@ namespace wsrep
 
         static const wsrep::id& undefined()
         {
-            static wsrep::id ret = wsrep::id();
-            return ret;
+            return undefined_;
         }
     private:
+        static const wsrep::id undefined_;
         unsigned char data_[16];
     };
 

--- a/src/gtid.cpp
+++ b/src/gtid.cpp
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <sstream>
 
+const wsrep::gtid wsrep::gtid::undefined_ = wsrep::gtid();
+
 std::ostream& wsrep::operator<<(std::ostream& os, const wsrep::gtid& gtid)
 {
     return (os << gtid.id() << ":" << gtid.seqno());

--- a/src/id.cpp
+++ b/src/id.cpp
@@ -24,6 +24,8 @@
 #include <sstream>
 #include <algorithm>
 
+const wsrep::id wsrep::id::undefined_ = wsrep::id();
+
 wsrep::id::id(const std::string& str)
     :  data_()
 {

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -249,8 +249,7 @@ namespace
     {
     public:
         const_ws_meta(const wsrep::ws_meta& ws_meta)
-            : ws_meta_(ws_meta)
-            , trx_meta_()
+            : trx_meta_()
         {
             std::memcpy(trx_meta_.gtid.uuid.data, ws_meta.group_id().data(),
                         sizeof(trx_meta_.gtid.uuid.data));
@@ -268,7 +267,6 @@ namespace
 
         const wsrep_trx_meta* native() const { return &trx_meta_; }
     private:
-        const wsrep::ws_meta& ws_meta_;
         wsrep_trx_meta_t trx_meta_;
     };
 

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -112,7 +112,7 @@ namespace wsrep
         }
 
         void cleanup_transaction() WSREP_OVERRIDE { }
-        size_t bytes_generated() const
+        size_t bytes_generated() const WSREP_OVERRIDE
         {
             return bytes_generated_;
         }

--- a/test/mock_high_priority_service.hpp
+++ b/test/mock_high_priority_service.hpp
@@ -43,7 +43,7 @@ namespace wsrep
         int start_transaction(const wsrep::ws_handle&, const wsrep::ws_meta&)
             WSREP_OVERRIDE;
 
-        const wsrep::transaction& transaction() const
+        const wsrep::transaction& transaction() const WSREP_OVERRIDE
         { return client_state_->transaction(); }
         void adopt_transaction(const wsrep::transaction&) WSREP_OVERRIDE;
         int apply_write_set(const wsrep::ws_meta&,

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -57,25 +57,27 @@ namespace wsrep
 
         enum wsrep::provider::status
         connect(const std::string&, const std::string&, const std::string&,
-                bool)
+                bool) WSREP_OVERRIDE
         { return wsrep::provider::success; }
-        int disconnect() { return 0; }
-        int capabilities() const { return 0; }
-        int desync() { return 0; }
-        int resync() { return 0; }
-        wsrep::seqno pause() { return wsrep::seqno(0); }
-        int resume() { return 0; }
+        int disconnect() WSREP_OVERRIDE { return 0; }
+        int capabilities() const WSREP_OVERRIDE { return 0; }
+        int desync() WSREP_OVERRIDE { return 0; }
+        int resync() WSREP_OVERRIDE { return 0; }
+        wsrep::seqno pause() WSREP_OVERRIDE { return wsrep::seqno(0); }
+        int resume() WSREP_OVERRIDE { return 0; }
         enum wsrep::provider::status run_applier(wsrep::high_priority_service*)
+            WSREP_OVERRIDE
         {
             return wsrep::provider::success;
         }
         // Provider implemenatation interface
-        int start_transaction(wsrep::ws_handle&) { return 0; }
+        int start_transaction(wsrep::ws_handle&) WSREP_OVERRIDE { return 0; }
         enum wsrep::provider::status
         certify(wsrep::client_id client_id,
                 wsrep::ws_handle& ws_handle,
                 int flags,
                 wsrep::ws_meta& ws_meta)
+            WSREP_OVERRIDE
         {
             ws_handle = wsrep::ws_handle(ws_handle.transaction_id(), (void*)1);
             wsrep::log_info() << "provider certify: "
@@ -142,11 +144,14 @@ namespace wsrep
         }
 
         int append_key(wsrep::ws_handle&, const wsrep::key&)
+            WSREP_OVERRIDE
         { return 0; }
         enum wsrep::provider::status
         append_data(wsrep::ws_handle&, const wsrep::const_buffer&)
+            WSREP_OVERRIDE
         { return wsrep::provider::success; }
         enum wsrep::provider::status rollback(const wsrep::transaction_id)
+        WSREP_OVERRIDE
         {
             ++fragments_;
             ++rollback_fragments_;
@@ -155,6 +160,7 @@ namespace wsrep
         enum wsrep::provider::status
         commit_order_enter(const wsrep::ws_handle& ws_handle,
                            const wsrep::ws_meta& ws_meta)
+            WSREP_OVERRIDE
         {
             BOOST_REQUIRE(ws_handle.opaque());
             BOOST_REQUIRE(ws_meta.seqno().is_undefined() == false);
@@ -163,6 +169,7 @@ namespace wsrep
 
         int commit_order_leave(const wsrep::ws_handle& ws_handle,
                                const wsrep::ws_meta& ws_meta)
+            WSREP_OVERRIDE
         {
             BOOST_REQUIRE(ws_handle.opaque());
             BOOST_REQUIRE(ws_meta.seqno().is_undefined() == false);
@@ -170,6 +177,7 @@ namespace wsrep
         }
 
         int release(wsrep::ws_handle& )
+            WSREP_OVERRIDE
         {
             // BOOST_REQUIRE(ws_handle.opaque());
             return release_result_;
@@ -178,6 +186,7 @@ namespace wsrep
         enum wsrep::provider::status replay(
             const wsrep::ws_handle& ws_handle,
             wsrep::high_priority_service* hps)
+            WSREP_OVERRIDE
         {
             wsrep::mock_high_priority_service& high_priority_service(
                 *static_cast<wsrep::mock_high_priority_service*>(hps));
@@ -223,8 +232,10 @@ namespace wsrep
                                                const wsrep::const_buffer&,
                                                wsrep::ws_meta&,
                                                int)
+            WSREP_OVERRIDE
         { return wsrep::provider::success; }
         enum wsrep::provider::status leave_toi(wsrep::client_id)
+            WSREP_OVERRIDE
         { return wsrep::provider::success; }
 
         std::pair<wsrep::gtid, enum wsrep::provider::status>
@@ -236,22 +247,24 @@ namespace wsrep
         enum wsrep::provider::status wait_for_gtid(const wsrep::gtid&,
             int) const WSREP_OVERRIDE
         { return wsrep::provider::success; }
-        wsrep::gtid last_committed_gtid() const { return wsrep::gtid(); }
-        int sst_sent(const wsrep::gtid&, int) { return 0; }
-        int sst_received(const wsrep::gtid&, int) { return 0; }
+        wsrep::gtid last_committed_gtid() const WSREP_OVERRIDE
+        { return wsrep::gtid(); }
+        int sst_sent(const wsrep::gtid&, int) WSREP_OVERRIDE { return 0; }
+        int sst_received(const wsrep::gtid&, int) WSREP_OVERRIDE { return 0; }
 
-        std::vector<status_variable> status() const
+        std::vector<status_variable> status() const WSREP_OVERRIDE
         {
             return std::vector<status_variable>();
         }
-        void reset_status() { }
-        std::string options() const { return ""; }
+        void reset_status() WSREP_OVERRIDE { }
+        std::string options() const WSREP_OVERRIDE { return ""; }
         enum wsrep::provider::status options(const std::string&)
+            WSREP_OVERRIDE
         { return wsrep::provider::success; }
         std::string name() const WSREP_OVERRIDE { return "mock"; }
         std::string version() const WSREP_OVERRIDE { return "0.0"; }
         std::string vendor() const WSREP_OVERRIDE { return "mock"; }
-        void* native() const { return 0; }
+        void* native() const WSREP_OVERRIDE { return 0; }
 
         //
         // Methods to modify mock state
@@ -266,6 +279,7 @@ namespace wsrep
         bf_abort(wsrep::seqno bf_seqno,
                  wsrep::transaction_id trx_id,
                  wsrep::seqno& victim_seqno)
+            WSREP_OVERRIDE
         {
             bf_abort_map_.insert(std::make_pair(trx_id, bf_seqno));
             if (bf_seqno.is_undefined() == false)

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -150,6 +150,7 @@ namespace wsrep
         }
         void log_state_change(enum wsrep::server_state::state,
                               enum wsrep::server_state::state)
+            WSREP_OVERRIDE
         { }
         bool sst_before_init() const WSREP_OVERRIDE
         { return sst_before_init_; }

--- a/test/mock_storage_service.cpp
+++ b/test/mock_storage_service.cpp
@@ -25,8 +25,7 @@
 wsrep::mock_storage_service::mock_storage_service(
     wsrep::server_state& server_state,
     wsrep::client_id client_id)
-    : server_state_(server_state)
-    , client_service_(client_state_)
+    : client_service_(client_state_)
     , client_state_(server_state, client_service_, client_id,
                     wsrep::client_state::m_high_priority)
 {

--- a/test/mock_storage_service.hpp
+++ b/test/mock_storage_service.hpp
@@ -55,7 +55,6 @@ class mock_server_state;
         void store_globals() WSREP_OVERRIDE { }
         void reset_globals() WSREP_OVERRIDE { }
     private:
-        wsrep::server_state& server_state_;
         wsrep::mock_client_service client_service_;
         wsrep::mock_client_state client_state_;
     };


### PR DESCRIPTION
Use default seqno and id constructors in default gtid ctor
instead of calls to static undefined to initialize.