### PR TITLE
Add method `query()` to client_service interface

### DIFF
--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -33,6 +33,7 @@ namespace db
     public:
         client_service(db::client& client);
 
+        std::string query() const override { return ""; }
         bool interrupted() const override { return false; }
         void reset_globals() override { }
         void store_globals() override { }

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -42,6 +42,12 @@ namespace wsrep
         virtual ~client_service() { }
 
         /**
+         * Returns a string that represents the query that is being
+         * executed by the client.
+         */
+        virtual std::string query() const = 0;
+
+        /**
          * Return true if the current transaction has been interrupted
          * by the DBMS.
          */

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1523,8 +1523,7 @@ void wsrep::transaction::cleanup()
     debug_log_state("cleanup_leave");
 }
 
-void wsrep::transaction::debug_log_state(
-    const char* context) const
+void wsrep::transaction::debug_log_state(const char* context) const
 {
     WSREP_TC_LOG_DEBUG(
         1, context
@@ -1550,7 +1549,7 @@ void wsrep::transaction::debug_log_state(
         << ", bytes: " << streaming_context_.bytes_certified()
         << ", sr_rb: " << streaming_context_.rolled_back()
         << "\n    own: " << (client_state_.owning_thread_id_ == wsrep::this_thread::get_id())
-        << "");
+        << "\n    query: " << client_service_.query());
 }
 
 void wsrep::transaction::debug_log_key_append(const wsrep::key& key)

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -75,6 +75,8 @@ namespace wsrep
             , aborts_()
         { }
 
+        std::string query() const WSREP_OVERRIDE { return ""; }
+
         int bf_rollback() WSREP_OVERRIDE;
 
         bool interrupted() const WSREP_OVERRIDE


### PR DESCRIPTION
The method should return the query that the client is currently
executing.