### PR TITLE
codership/wsrep-lib#71 to make output cleaner with additional space

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -338,7 +338,7 @@ int wsrep::server_state::load_provider(const std::string& provider_spec,
                                        const std::string& provider_options)
 {
     wsrep::log_info() << "Loading provider " << provider_spec
-                      << "initial position: " << initial_position_;
+                      << " initial position: " << initial_position_;
 
     provider_ = wsrep::provider::make_provider(*this,
                                                provider_spec,


### PR DESCRIPTION
Added space in `int wsrep::server_state::load_provider`:

```
wsrep::log_info() << "Loading provider " << provider_spec
                      << " initial position: " << initial_position_;
```

Now it should have cleaner output.