### PR TITLE
avoid simple pass through methods in high_priority_service

### DIFF
--- a/dbsim/db_high_priority_service.cpp
+++ b/dbsim/db_high_priority_service.cpp
@@ -28,26 +28,9 @@ db::high_priority_service::high_priority_service(
     , client_(client)
 { }
 
-int db::high_priority_service::start_transaction(
-    const wsrep::ws_handle& ws_handle,
-    const wsrep::ws_meta& ws_meta)
+wsrep::client_state& db::high_priority_service::client_state()
 {
-    return client_.client_state().start_transaction(ws_handle, ws_meta);
-}
-
-int db::high_priority_service::next_fragment(const wsrep::ws_meta& ws_meta)
-{
-    return client_.client_state().next_fragment(ws_meta);
-}
-
-const wsrep::transaction& db::high_priority_service::transaction() const
-{
-    return client_.client_state().transaction();
-}
-
-void db::high_priority_service::adopt_transaction(const wsrep::transaction&)
-{
-    throw wsrep::not_implemented_error();
+    return client_.client_state();
 }
 
 int db::high_priority_service::apply_write_set(

--- a/dbsim/db_high_priority_service.hpp
+++ b/dbsim/db_high_priority_service.hpp
@@ -30,11 +30,7 @@ namespace db
     {
     public:
         high_priority_service(db::server& server, db::client& client);
-        int start_transaction(const wsrep::ws_handle&,
-                              const wsrep::ws_meta&) override;
-        int next_fragment(const wsrep::ws_meta&) override;
-        const wsrep::transaction& transaction() const override;
-        void adopt_transaction(const wsrep::transaction&) override;
+        wsrep::client_state& client_state() override;
         int apply_write_set(const wsrep::ws_meta&,
                             const wsrep::const_buffer&) override;
         int append_fragment_and_commit(

--- a/include/wsrep/high_priority_service.hpp
+++ b/include/wsrep/high_priority_service.hpp
@@ -45,27 +45,12 @@ namespace wsrep
         {
             return server_state_.on_apply(*this, ws_handle, ws_meta, data);
         }
-        /**
-         * Start a new transaction
-         */
-        virtual int start_transaction(const wsrep::ws_handle&,
-                                      const wsrep::ws_meta&) = 0;
 
         /**
-         * Start the next fragment of current transaction
+         * Inner client state. Avoids the need for having simple "pass through"
+         * methods in the interface.
          */
-        virtual int next_fragment(const wsrep::ws_meta&) = 0;
-
-        /**
-         * Return transaction object associated to high priority
-         * service state.
-         */
-        virtual const wsrep::transaction& transaction() const = 0;
-
-        /**
-         * Adopt a transaction.
-         */
-        virtual void adopt_transaction(const wsrep::transaction&) = 0;
+        virtual wsrep::client_state& client_state() = 0;
 
         /**
          * Apply a write set.

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1012,7 +1012,7 @@ inline wsrep::provider& wsrep::transaction::provider()
 }
 
 void wsrep::transaction::state(
-    wsrep::unique_lock<wsrep::mutex>& lock __attribute__((unused)),
+    wsrep::unique_lock<wsrep::mutex>& lock WSREP_UNUSED,
     enum wsrep::transaction::state next_state)
 {
     WSREP_LOG_DEBUG(client_state_.debug_log_level(),

--- a/test/mock_high_priority_service.cpp
+++ b/test/mock_high_priority_service.cpp
@@ -20,21 +20,9 @@
 #include "mock_high_priority_service.hpp"
 #include "mock_server_state.hpp"
 
-int wsrep::mock_high_priority_service::start_transaction(
-    const wsrep::ws_handle& ws_handle, const wsrep::ws_meta& ws_meta)
+wsrep::client_state& wsrep::mock_high_priority_service::client_state()
 {
-    return client_state_->start_transaction(ws_handle, ws_meta);
-}
-
-int wsrep::mock_high_priority_service::next_fragment(const wsrep::ws_meta& ws_meta)
-{
-    return client_state_->next_fragment(ws_meta);
-}
-
-void wsrep::mock_high_priority_service::adopt_transaction(
-    const wsrep::transaction& transaction)
-{
-    client_state_->adopt_transaction(transaction);
+    return *client_state_;
 }
 
 int wsrep::mock_high_priority_service::apply_write_set(

--- a/test/mock_high_priority_service.hpp
+++ b/test/mock_high_priority_service.hpp
@@ -40,14 +40,7 @@ namespace wsrep
             , replaying_(replaying)
         { }
 
-        int start_transaction(const wsrep::ws_handle&, const wsrep::ws_meta&)
-            WSREP_OVERRIDE;
-
-        int next_fragment(const wsrep::ws_meta&) WSREP_OVERRIDE;
-
-        const wsrep::transaction& transaction() const WSREP_OVERRIDE
-        { return client_state_->transaction(); }
-        void adopt_transaction(const wsrep::transaction&) WSREP_OVERRIDE;
+        wsrep::client_state& client_state() WSREP_OVERRIDE;
         int apply_write_set(const wsrep::ws_meta&,
                             const wsrep::const_buffer&) WSREP_OVERRIDE;
         int append_fragment_and_commit(
@@ -73,7 +66,7 @@ namespace wsrep
         bool is_replaying() const WSREP_OVERRIDE { return replaying_; }
         void debug_crash(const char*) WSREP_OVERRIDE { /* Not in unit tests*/}
 
-        wsrep::mock_client_state* client_state()
+        wsrep::mock_client_state* mock_client_state()
         {
             return client_state_;
         }

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -191,7 +191,7 @@ namespace wsrep
             wsrep::mock_high_priority_service& high_priority_service(
                 *static_cast<wsrep::mock_high_priority_service*>(hps));
             wsrep::mock_client_state& cc(
-                *high_priority_service.client_state());
+                *high_priority_service.mock_client_state());
             wsrep::high_priority_context high_priority_context(cc);
             const wsrep::transaction& tc(cc.transaction());
             wsrep::ws_meta ws_meta;

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -103,7 +103,7 @@ namespace wsrep
             mock_high_priority_service* mhps(
                 static_cast<mock_high_priority_service*>(high_priority_service));
             wsrep::mock_client* cs(static_cast<wsrep::mock_client*>(
-                                       mhps->client_state()));
+                                       mhps->mock_client_state()));
             cs->after_command_before_result();
             cs->after_command_after_result();
             cs->close();


### PR DESCRIPTION
- new method returning client_state to avoid having simple pass
  through methods to the inner object