### PR TITLE
Reset client state gtid state in client_state::open()

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -38,6 +38,8 @@ void wsrep::client_state::open(wsrep::client_id id)
     owning_thread_id_ = wsrep::this_thread::get_id();
     current_thread_id_ = owning_thread_id_;
     has_rollbacker_ = false;
+    sync_wait_gtid_ = wsrep::gtid::undefined();
+    last_written_gtid_ = wsrep::gtid::undefined();
     state(lock, s_idle);
     id_ = id;
     debug_log_state("open: leave");


### PR DESCRIPTION
If the application uses caching for client sessions, the
client_state object may be reused. This will cause the opened
client session to have unexpected value for sync_wait_gtid and
last_written_gtid.

In order to work around the problem, reset sync_wait_gtid and
last_written_gtid in client_state::open().