### PR TITLE
codership/wsrep-lib#90 Fixed assertion in before_commit()

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -373,7 +373,8 @@ int wsrep::transaction::before_commit()
                    ||
                    (state() == s_must_abort ||
                     state() == s_must_replay ||
-                    state() == s_cert_failed));
+                    state() == s_cert_failed ||
+                    state() == s_aborted));
         }
         else if (state() != s_committing)
         {


### PR DESCRIPTION
Added unit test which makes assertion to fail if the fix is not
present.