### PR TITLE
Return error code from high_priority_service::adopt_transaction()

### DIFF
--- a/dbsim/db_high_priority_service.cpp
+++ b/dbsim/db_high_priority_service.cpp
@@ -40,7 +40,7 @@ const wsrep::transaction& db::high_priority_service::transaction() const
     return client_.client_state().transaction();
 }
 
-void db::high_priority_service::adopt_transaction(const wsrep::transaction&)
+int db::high_priority_service::adopt_transaction(const wsrep::transaction&)
 {
     throw wsrep::not_implemented_error();
 }

--- a/dbsim/db_high_priority_service.hpp
+++ b/dbsim/db_high_priority_service.hpp
@@ -33,7 +33,7 @@ namespace db
         int start_transaction(const wsrep::ws_handle&,
                               const wsrep::ws_meta&) override;
         const wsrep::transaction& transaction() const override;
-        void adopt_transaction(const wsrep::transaction&) override;
+        int adopt_transaction(const wsrep::transaction&) override;
         int apply_write_set(const wsrep::ws_meta&,
                             const wsrep::const_buffer&) override;
         int append_fragment_and_commit(

--- a/include/wsrep/high_priority_service.hpp
+++ b/include/wsrep/high_priority_service.hpp
@@ -60,7 +60,7 @@ namespace wsrep
         /**
          * Adopt a transaction.
          */
-        virtual void adopt_transaction(const wsrep::transaction&) = 0;
+        virtual int adopt_transaction(const wsrep::transaction&) = 0;
 
         /**
          * Apply a write set.

--- a/test/mock_high_priority_service.cpp
+++ b/test/mock_high_priority_service.cpp
@@ -26,10 +26,11 @@ int wsrep::mock_high_priority_service::start_transaction(
     return client_state_->start_transaction(ws_handle, ws_meta);
 }
 
-void wsrep::mock_high_priority_service::adopt_transaction(
+int wsrep::mock_high_priority_service::adopt_transaction(
     const wsrep::transaction& transaction)
 {
     client_state_->adopt_transaction(transaction);
+    return 0;
 }
 
 int wsrep::mock_high_priority_service::apply_write_set(

--- a/test/mock_high_priority_service.hpp
+++ b/test/mock_high_priority_service.hpp
@@ -45,7 +45,7 @@ namespace wsrep
 
         const wsrep::transaction& transaction() const WSREP_OVERRIDE
         { return client_state_->transaction(); }
-        void adopt_transaction(const wsrep::transaction&) WSREP_OVERRIDE;
+        int adopt_transaction(const wsrep::transaction&) WSREP_OVERRIDE;
         int apply_write_set(const wsrep::ws_meta&,
                             const wsrep::const_buffer&) WSREP_OVERRIDE;
         int append_fragment_and_commit(


### PR DESCRIPTION
Adopt transaction may need to start a new transaction on DBMS side,
allow returning an error if the transaction start fails.