### PR TITLE
close SR transacions on equal consecutive views

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -355,6 +355,7 @@ namespace wsrep
          *  Return current view
          */
         const wsrep::view& current_view() const { return current_view_; }
+
         /**
          * Set last committed GTID.
          */

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -356,10 +356,6 @@ namespace wsrep
          */
         const wsrep::view& current_view() const { return current_view_; }
         /**
-         *  Return the previous primary view
-         */
-        const wsrep::view& previous_primary_view() const { return previous_primary_view_; }
-        /**
          * Set last committed GTID.
          */
         void last_committed_gtid(const wsrep::gtid&);

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -356,6 +356,10 @@ namespace wsrep
          */
         const wsrep::view& current_view() const { return current_view_; }
         /**
+         *  Return the previous primary view
+         */
+        const wsrep::view& previous_primary_view() const { return previous_primary_view_; }
+        /**
          * Set last committed GTID.
          */
         void last_committed_gtid(const wsrep::gtid&);
@@ -603,6 +607,7 @@ namespace wsrep
             , max_protocol_version_(max_protocol_version)
             , rollback_mode_(rollback_mode)
             , connected_gtid_()
+            , previous_primary_view_()
             , current_view_()
             , last_committed_gtid_()
         { }
@@ -692,6 +697,7 @@ namespace wsrep
         int max_protocol_version_;
         enum rollback_mode rollback_mode_;
         wsrep::gtid connected_gtid_;
+        wsrep::view previous_primary_view_;
         wsrep::view current_view_;
         wsrep::gtid last_committed_gtid_;
     };

--- a/include/wsrep/view.hpp
+++ b/include/wsrep/view.hpp
@@ -103,6 +103,11 @@ namespace wsrep
         ssize_t own_index() const
         { return own_index_; }
 
+        /**
+         * Return true if the two views have the same membership
+         */
+        bool equal_membership(const wsrep::view& other) const;
+
         int protocol_version() const
         { return protocol_version_; }
         const std::vector<member>& members() const { return members_; }

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -612,7 +612,8 @@ void wsrep::server_state::sst_received(wsrep::client_service& cs,
                 throw wsrep::runtime_error(msg.str());
             }
 
-            if (current_view_.status() == wsrep::view::primary) {
+            if (current_view_.status() == wsrep::view::primary)
+            {
                 previous_primary_view_ = current_view_;
             }
             current_view_ = v;
@@ -901,7 +902,8 @@ void wsrep::server_state::on_view(const wsrep::view& view,
                           << "name: " << i->name();
     }
     wsrep::log_info() << "=================================================";
-    if (current_view_.status() == wsrep::view::primary) {
+    if (current_view_.status() == wsrep::view::primary)
+    {
         previous_primary_view_ = current_view_;
     }
     current_view_ = view;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -43,7 +43,8 @@ bool wsrep::view::equal_membership(const wsrep::view& other) const
     for (std::vector<member>::const_iterator i(members_.begin());
          i != members_.end(); ++i)
     {
-        if (other.member_index(i->id()) == -1) {
+        if (other.member_index(i->id()) == -1)
+        {
             return false;
         }
     }
@@ -54,7 +55,7 @@ void wsrep::view::print(std::ostream& os) const
 {
     os << "  id: " << state_id() << "\n"
        << "  status: " << to_c_string(status()) << "\n"
-       << "  prococol_version: " << protocol_version() << "\n"
+       << "  protocol_version: " << protocol_version() << "\n"
        << "  capabilities: " << provider::capability::str(capabilities())<<"\n"
        << "  final: " << (final() ? "yes" : "no") << "\n"
        << "  own_index: " << own_index() << "\n"

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -33,6 +33,23 @@ int wsrep::view::member_index(const wsrep::id& member_id) const
     return -1;
 }
 
+bool wsrep::view::equal_membership(const wsrep::view& other) const
+{
+    if (members_.size() != other.members_.size())
+    {
+        return false;
+    }
+    // we can't assume members ordering
+    for (std::vector<member>::const_iterator i(members_.begin());
+         i != members_.end(); ++i)
+    {
+        if (other.member_index(i->id()) == -1) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void wsrep::view::print(std::ostream& os) const
 {
     os << "  id: " << state_id() << "\n"

--- a/test/view_test.cpp
+++ b/test/view_test.cpp
@@ -28,12 +28,12 @@ BOOST_AUTO_TEST_CASE(view_test_member_index)
     members.push_back(wsrep::view::member(wsrep::id("3"), "", ""));
 
     wsrep::view view(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
-		     wsrep::seqno(1),
-		     wsrep::view::primary,
-		     0,
-		     1,
-		     0,
-		     members);
+                     wsrep::seqno(1),
+                     wsrep::view::primary,
+                     0,
+                     1,
+                     0,
+                     members);
     BOOST_REQUIRE(view.member_index(wsrep::id("1")) == 0);
     BOOST_REQUIRE(view.member_index(wsrep::id("2")) == 1);
     BOOST_REQUIRE(view.member_index(wsrep::id("3")) == 2);
@@ -59,28 +59,28 @@ BOOST_AUTO_TEST_CASE(view_test_equal_membership)
     m3.push_back(wsrep::view::member(wsrep::id("4"), "", ""));
 
     wsrep::view v1(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
-		     wsrep::seqno(1),
-		     wsrep::view::primary,
-		     0,
-		     1,
-		     0,
-             m1);
+                   wsrep::seqno(1),
+                   wsrep::view::primary,
+                   0,
+                   1,
+                   0,
+                   m1);
 
     wsrep::view v2(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
-		     wsrep::seqno(1),
-		     wsrep::view::primary,
-		     0,
-		     1,
-		     0,
-		     m2);
+                   wsrep::seqno(1),
+                   wsrep::view::primary,
+                   0,
+                   1,
+                   0,
+                   m2);
 
     wsrep::view v3(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
-		     wsrep::seqno(1),
-		     wsrep::view::primary,
-		     0,
-		     1,
-		     0,
-		     m3);
+                   wsrep::seqno(1),
+                   wsrep::view::primary,
+                   0,
+                   1,
+                   0,
+                   m3);
 
     BOOST_REQUIRE(v1.equal_membership(v2));
     BOOST_REQUIRE(v2.equal_membership(v1));

--- a/test/view_test.cpp
+++ b/test/view_test.cpp
@@ -39,3 +39,51 @@ BOOST_AUTO_TEST_CASE(view_test_member_index)
     BOOST_REQUIRE(view.member_index(wsrep::id("3")) == 2);
     BOOST_REQUIRE(view.member_index(wsrep::id("4")) == -1);
 }
+
+BOOST_AUTO_TEST_CASE(view_test_equal_membership)
+{
+    std::vector<wsrep::view::member> m1;
+    m1.push_back(wsrep::view::member(wsrep::id("1"), "", ""));
+    m1.push_back(wsrep::view::member(wsrep::id("2"), "", ""));
+    m1.push_back(wsrep::view::member(wsrep::id("3"), "", ""));
+
+    std::vector<wsrep::view::member> m2;
+    m2.push_back(wsrep::view::member(wsrep::id("2"), "", ""));
+    m2.push_back(wsrep::view::member(wsrep::id("3"), "", ""));
+    m2.push_back(wsrep::view::member(wsrep::id("1"), "", ""));
+
+    std::vector<wsrep::view::member> m3;
+    m3.push_back(wsrep::view::member(wsrep::id("1"), "", ""));
+    m3.push_back(wsrep::view::member(wsrep::id("2"), "", ""));
+    m3.push_back(wsrep::view::member(wsrep::id("3"), "", ""));
+    m3.push_back(wsrep::view::member(wsrep::id("4"), "", ""));
+
+    wsrep::view v1(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
+		     wsrep::seqno(1),
+		     wsrep::view::primary,
+		     0,
+		     1,
+		     0,
+             m1);
+
+    wsrep::view v2(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
+		     wsrep::seqno(1),
+		     wsrep::view::primary,
+		     0,
+		     1,
+		     0,
+		     m2);
+
+    wsrep::view v3(wsrep::gtid(wsrep::id("cluster"), wsrep::seqno(1)),
+		     wsrep::seqno(1),
+		     wsrep::view::primary,
+		     0,
+		     1,
+		     0,
+		     m3);
+
+    BOOST_REQUIRE(v1.equal_membership(v2));
+    BOOST_REQUIRE(v2.equal_membership(v1));
+    BOOST_REQUIRE(!v1.equal_membership(v3));
+    BOOST_REQUIRE(!v3.equal_membership(v1));
+}


### PR DESCRIPTION
Fixes a bug where the fact that an SR master leaves the primary view
gets missed. When two consecutive primary views have the same
membership we now assume that every SR needs to be rolled back, as the
system may have been through a state of only non-primary components.