### PR TITLE
use `log_position` when calculating bytes_to_replicate

### DIFF
--- a/include/wsrep/streaming_context.hpp
+++ b/include/wsrep/streaming_context.hpp
@@ -45,7 +45,6 @@ namespace wsrep
             , rollback_replicated_for_()
             , fragment_unit_()
             , fragment_size_()
-            , bytes_certified_()
             , unit_counter_()
             , log_position_()
         { }
@@ -102,10 +101,9 @@ namespace wsrep
             fragment_size_ = 0;
         }
 
-        void certified(size_t bytes)
+        void certified()
         {
             ++fragments_certified_;
-            bytes_certified_ += bytes;
         }
 
         size_t fragments_certified() const
@@ -129,11 +127,6 @@ namespace wsrep
             check_fragment_seqno(seqno);
             ++fragments_certified_;
             fragments_.push_back(seqno);
-        }
-
-        size_t bytes_certified() const
-        {
-            return bytes_certified_;
         }
 
         void rolled_back(wsrep::transaction_id id)
@@ -193,7 +186,6 @@ namespace wsrep
             fragments_certified_ = 0;
             fragments_.clear();
             rollback_replicated_for_ = wsrep::transaction_id::undefined();
-            bytes_certified_ = 0;
             unit_counter_ = 0;
             log_position_ = 0;
         }
@@ -210,7 +202,6 @@ namespace wsrep
         wsrep::transaction_id rollback_replicated_for_;
         enum fragment_unit fragment_unit_;
         size_t fragment_size_;
-        size_t bytes_certified_;
         size_t unit_counter_;
         size_t log_position_;
     };

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1271,7 +1271,7 @@ int wsrep::transaction::certify_fragment(
             case wsrep::provider::success:
                 ++fragments_certified_for_statement_;
                 assert(sr_ws_meta.seqno().is_undefined() == false);
-                streaming_context_.certified(data.size());
+                streaming_context_.certified();
                 if (storage_service.update_fragment_meta(sr_ws_meta))
                 {
                     storage_service.rollback(wsrep::ws_handle(),
@@ -1311,7 +1311,7 @@ int wsrep::transaction::certify_fragment(
                 // we take a risk of sending one rollback fragment for nothing.
                 storage_service.rollback(wsrep::ws_handle(),
                                          wsrep::ws_meta());
-                streaming_context_.certified(data.size());
+                streaming_context_.certified();
                 ret = 1;
                 error = wsrep::e_deadlock_error;
                 break;
@@ -1678,7 +1678,6 @@ void wsrep::transaction::debug_log_state(
         << ", size: " << streaming_context_.fragment_size()
         << ", counter: " << streaming_context_.unit_counter()
         << ", log_pos: " << streaming_context_.log_position()
-        << ", bytes: " << streaming_context_.bytes_certified()
         << ", sr_rb: " << streaming_context_.rolled_back()
         << "\n    own: " << (client_state_.owning_thread_id_ == wsrep::this_thread::get_id())
         << " thread_id: " << client_state_.owning_thread_id_

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1129,7 +1129,7 @@ int wsrep::transaction::streaming_step(wsrep::unique_lock<wsrep::mutex>& lock)
 
     int ret(0);
     const ssize_t bytes_to_replicate(client_service_.bytes_generated() -
-                                     streaming_context_.bytes_certified());
+                                     streaming_context_.log_position());
 
     switch (streaming_context_.fragment_unit())
     {
@@ -1677,6 +1677,7 @@ void wsrep::transaction::debug_log_state(
         << ", unit: " << streaming_context_.fragment_unit()
         << ", size: " << streaming_context_.fragment_size()
         << ", counter: " << streaming_context_.unit_counter()
+        << ", log_pos: " << streaming_context_.log_position()
         << ", bytes: " << streaming_context_.bytes_certified()
         << ", sr_rb: " << streaming_context_.rolled_back()
         << "\n    own: " << (client_state_.owning_thread_id_ == wsrep::this_thread::get_id())


### PR DESCRIPTION
`bytes_certified` includes XA events which are not written to the
binlog. Thus, we need to use `log_position` instead.
Also added log_position `debug_log_state`.