### PR TITLE
Support recovery of XA transactions

### DIFF
--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -52,6 +52,10 @@ namespace db
         {
             return false;
         }
+        std::string xid() const override
+        {
+            return "";
+        }
         size_t bytes_generated() const override
         {
             return 0;

--- a/dbsim/db_high_priority_service.hpp
+++ b/dbsim/db_high_priority_service.hpp
@@ -39,8 +39,9 @@ namespace db
                             const wsrep::const_buffer&) override;
         int append_fragment_and_commit(
             const wsrep::ws_handle&,
-            const wsrep::ws_meta&, const wsrep::const_buffer&)
-            override
+            const wsrep::ws_meta&,
+            const wsrep::const_buffer&,
+            const std::string&) override
         { return 0; }
         int remove_fragments(const wsrep::ws_meta&) override
         { return 0; }

--- a/dbsim/db_storage_service.hpp
+++ b/dbsim/db_storage_service.hpp
@@ -34,7 +34,8 @@ namespace db
         int append_fragment(const wsrep::id&,
                             wsrep::transaction_id,
                             int,
-                            const wsrep::const_buffer&) override
+                            const wsrep::const_buffer&,
+                            const std::string&) override
         { throw wsrep::not_implemented_error(); }
         int update_fragment_meta(const wsrep::ws_meta&) override
         { throw wsrep::not_implemented_error(); }

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -73,6 +73,9 @@ namespace wsrep
          */
         virtual void cleanup_transaction() = 0;
 
+        //
+        // XA
+        //
         /**
          * Return true if the current transactions is XA
          */
@@ -82,6 +85,11 @@ namespace wsrep
          * Return true if the current statement is XA PREPARE
          */
         virtual bool is_xa_prepare() const = 0;
+
+        /**
+         * Return a string representing the xid of the transaction
+         */
+        virtual std::string xid() const = 0;
 
         //
         // Streaming

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -271,6 +271,36 @@ namespace wsrep
         }
 
         /**
+         * Restores the client's transaction to prepared state
+         *
+         * The purpose of this method is to restore transaction state
+         * during recovery of a prepared XA transaction.
+         */
+        int restore_prepared_transaction()
+        {
+            return transaction_.restore_to_prepared_state();
+        }
+
+        /**
+         * Terminate transaction with the given xid
+         *
+         * Sends a commit or rollback fragment to terminate the a
+         * transaction with the given xid. For the fragment to be
+         * sent, a streaming applier for the transaction must exist
+         * and the transaction must be in prepared state.
+         *
+         * @param xid the xid of the the transaction to terminate
+         * @param commit whether to send a commmit or rollback fragment
+         *
+         * @return Zero on success, non-zero on error. In case of error
+         *         the client_state's current_error is set
+         */
+        int commit_or_rollback_by_xid(const std::string& xid, bool commit)
+        {
+            return transaction_.commit_or_rollback_by_xid(xid, commit);
+        }
+
+        /**
          * Append a key into transaction write set.
          */
         int append_key(const wsrep::key& key)

--- a/include/wsrep/high_priority_service.hpp
+++ b/include/wsrep/high_priority_service.hpp
@@ -92,7 +92,8 @@ namespace wsrep
         virtual int append_fragment_and_commit(
             const wsrep::ws_handle& ws_handle,
             const wsrep::ws_meta& ws_meta,
-            const wsrep::const_buffer& data) = 0;
+            const wsrep::const_buffer& data,
+            const std::string& xid) = 0;
 
         /**
          * Remove fragments belonging to streaming transaction.

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -107,7 +107,12 @@ namespace wsrep
             , depends_on_(depends_on)
             , flags_(flags)
         { }
-
+        ws_meta(const wsrep::stid& stid)
+            : gtid_()
+            , stid_(stid)
+            , depends_on_()
+            , flags_()
+        { }
         const wsrep::gtid& gtid() const { return gtid_; }
         const wsrep::id& group_id() const
         {

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -250,12 +250,20 @@ namespace wsrep
 
         void stop_streaming_applier(
             const wsrep::id&, const wsrep::transaction_id&);
+
         /**
-         * Return reference to streaming applier.
+         * Find a streaming applier matching server and transaction ids
          */
         wsrep::high_priority_service* find_streaming_applier(
             const wsrep::id&,
             const wsrep::transaction_id&) const;
+
+        /**
+         * Find a streaming applier matching xid
+         */
+        wsrep::high_priority_service* find_streaming_applier(
+            const std::string& xid) const;
+
         /**
          * Load WSRep provider.
          *

--- a/include/wsrep/storage_service.hpp
+++ b/include/wsrep/storage_service.hpp
@@ -63,7 +63,8 @@ namespace wsrep
         virtual int append_fragment(const wsrep::id& server_id,
                                     wsrep::transaction_id client_id,
                                     int flags,
-                                    const wsrep::const_buffer& data) = 0;
+                                    const wsrep::const_buffer& data,
+                                    const std::string& xid) = 0;
 
         /**
          * Update fragment meta data after certification process.

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -130,6 +130,15 @@ namespace wsrep
             return client_service_.is_xa_prepare();
         }
 
+        int restore_to_prepared_state();
+
+        int commit_or_rollback_by_xid(const std::string& xid, bool commit);
+
+        const std::string xid() const
+        {
+            return client_service_.xid();
+        }
+
         bool pa_unsafe() const { return pa_unsafe_; }
         void pa_unsafe(bool pa_unsafe) { pa_unsafe_ = pa_unsafe; }
 

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -75,13 +75,18 @@ static int apply_fragment(wsrep::high_priority_service& high_priority_service,
         streaming_applier.after_apply();
     }
     high_priority_service.debug_crash("crash_apply_cb_before_append_frag");
-    ret = ret || high_priority_service.append_fragment_and_commit(
-        ws_handle, ws_meta, data);
+    if (!ret)
+    {
+        const std::string xid(streaming_applier.transaction().xid());
+        ret = high_priority_service.append_fragment_and_commit(ws_handle,
+                                                               ws_meta,
+                                                               data,
+                                                               xid);
+    }
     high_priority_service.debug_crash("crash_apply_cb_after_append_frag");
     high_priority_service.after_apply();
     return ret;
 }
-
 
 static int commit_fragment(wsrep::server_state& server_state,
                            wsrep::high_priority_service& high_priority_service,
@@ -155,6 +160,7 @@ static int rollback_fragment(wsrep::server_state& server_state,
         streaming_applier->rollback(wsrep::ws_handle(), wsrep::ws_meta());
         streaming_applier->after_apply();
     }
+
     server_state.stop_streaming_applier(
         ws_meta.server_id(), ws_meta.transaction_id());
     server_state.server_service().release_high_priority_service(
@@ -1134,6 +1140,21 @@ wsrep::high_priority_service* wsrep::server_state::find_streaming_applier(
     return (i == streaming_appliers_.end() ? 0 : i->second);
 }
 
+wsrep::high_priority_service* wsrep::server_state::find_streaming_applier(
+  const std::string& xid) const
+{
+    wsrep::unique_lock<wsrep::mutex> lock(mutex_);
+    for (auto const& i : streaming_appliers_)
+    {
+        wsrep::high_priority_service* sa(i.second);
+        if (sa->transaction().xid() == xid)
+        {
+            return sa;
+        }
+    }
+    return nullptr;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //                              Private                                     //
 //////////////////////////////////////////////////////////////////////////////
@@ -1308,13 +1329,19 @@ void wsrep::server_state::close_orphaned_sr_transactions(
     streaming_appliers_map::iterator i(streaming_appliers_.begin());
     while (i != streaming_appliers_.end())
     {
-        // rollback SR on equal consecutive primary views or if its
-        // originator is not in the current view
-        if (equal_consecutive_views ||
-            (std::find_if(current_view_.members().begin(),
-                          current_view_.members().end(),
-                          server_id_cmp(i->first.first)) ==
-             current_view_.members().end()))
+        wsrep::high_priority_service* streaming_applier(i->second);
+
+        // Rollback SR on equal consecutive primary views or if its
+        // originator is not in the current view.
+        // Transactions in prepared state must be committed or
+        // rolled back explicitly, those are never rolled back here.
+        if ((streaming_applier->transaction().state() !=
+             wsrep::transaction::s_prepared) &&
+            (equal_consecutive_views ||
+             (std::find_if(current_view_.members().begin(),
+                           current_view_.members().end(),
+                           server_id_cmp(i->first.first)) ==
+              current_view_.members().end())))
         {
             WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
                             wsrep::log::debug_level_server_state,
@@ -1323,7 +1350,6 @@ void wsrep::server_state::close_orphaned_sr_transactions(
                             << ", " << i->first.second);
             wsrep::id server_id(i->first.first);
             wsrep::transaction_id transaction_id(i->first.second);
-            wsrep::high_priority_service* streaming_applier(i->second);
             int adopt_error;
             if ((adopt_error = high_priority_service.adopt_transaction(
                      streaming_applier->transaction())))

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -222,7 +222,12 @@ namespace
             : ws_meta_(ws_meta)
             , trx_meta_()
             , flags_(flags)
-        { }
+        {
+          std::memcpy(trx_meta_.stid.node.data, ws_meta.server_id().data(),
+                      sizeof(trx_meta_.stid.node.data));
+          trx_meta_.stid.conn = ws_meta.client_id().get();
+          trx_meta_.stid.trx = ws_meta.transaction_id().get();
+        }
 
         ~mutable_ws_meta()
         {

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -141,6 +141,11 @@ namespace wsrep
             return is_xa_prepare_;
         }
 
+        std::string xid() const WSREP_OVERRIDE
+        {
+            return "";
+        }
+
         size_t bytes_generated() const WSREP_OVERRIDE
         {
             return bytes_generated_;

--- a/test/mock_high_priority_service.hpp
+++ b/test/mock_high_priority_service.hpp
@@ -53,7 +53,8 @@ namespace wsrep
         int append_fragment_and_commit(
             const wsrep::ws_handle&,
             const wsrep::ws_meta&,
-            const wsrep::const_buffer&) WSREP_OVERRIDE
+            const wsrep::const_buffer&,
+            const std::string&) WSREP_OVERRIDE
         { return 0; }
         int remove_fragments(const wsrep::ws_meta&) WSREP_OVERRIDE
         { return 0; }

--- a/test/mock_storage_service.hpp
+++ b/test/mock_storage_service.hpp
@@ -39,8 +39,8 @@ class mock_server_state;
         int append_fragment(const wsrep::id&,
                             wsrep::transaction_id,
                             int,
-                            const wsrep::const_buffer&)
-            WSREP_OVERRIDE
+                            const wsrep::const_buffer&,
+                            const std::string&) WSREP_OVERRIDE
         { return 0; }
 
         int update_fragment_meta(const wsrep::ws_meta&) WSREP_OVERRIDE


### PR DESCRIPTION
* Add method `restore_prepared_transaction` to `client_state` class
  which restores a transaction state from storage given its xid.
* Make sure that transactions in prepared state are not rolled back
  when their master fails/partitions away.