### PR TITLE
Write wsrep-lib log from unit tests into file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,5 +245,5 @@ script:
             -DWSREP_LIB_WITH_DBSIM:BOOL=${DBSIM}
             -DWSREP_LIB_WITH_ASAN:BOOL=${ASAN}
   - make VERBOSE=1 -j 4
-  - make test
+  - make test ARGS=--verbose
 

--- a/test/wsrep-lib_test.cpp
+++ b/test/wsrep-lib_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -17,6 +17,85 @@
  * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE wsrep_test
+/** @file wsrep-lib_test.cpp
+ *
+ * Run wsrep-lib unit tests.
+ *
+ * Commandline arguments:
+ *
+ * --wsrep-log-file=<file> Write log from wsrep-lib logging facility
+ *                         into <file>. If <file> is left empty, the
+ *                         log is written into stdout.
+ */
+
+#include "wsrep/logger.hpp"
+#include <fstream>
+
+#define BOOST_TEST_ALTERNATIVE_INIT_API
 #include <boost/test/included/unit_test.hpp>
 
+// Log file to write messages logged via wsrep-lib logging facility.
+static std::string log_file_name("wsrep-lib_test.log");
+static std::ofstream log_file;
+
+static void log_fn(wsrep::log::level level,
+                   const char* msg)
+{
+    log_file << wsrep::log::to_c_string(level) << ": " << msg << std::endl;
+}
+
+static bool parse_arg(const std::string& arg)
+{
+    const std::string delim("=");
+    auto delim_pos(arg.find(delim));
+    const auto parm(arg.substr(0, delim_pos));
+    std::string val;
+    if (delim_pos != std::string::npos)
+    {
+        val = arg.substr(delim_pos + 1);
+    }
+
+    if (parm == "--wsrep-log-file")
+    {
+        log_file_name = val;
+    }
+    else
+    {
+        std::cerr << "Error: Unknown argument " << arg << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool setup_env(int argc, char* argv[])
+{
+    for (int i(1); i < argc; ++i)
+    {
+        if (parse_arg(argv[i]) == false)
+        {
+            return false;
+        }
+    }
+
+    if (log_file_name.size())
+    {
+        log_file.open(log_file_name);
+        if (!log_file)
+        {
+            int err(errno);
+            std::cerr << "Failed to open '" << log_file_name
+                      << "': '" << ::strerror(err) << "'" << std::endl;
+            return false;
+        }
+        std::cout << "Writing wsrep-lib log into '" << log_file_name << "'"
+                  << std::endl;
+        wsrep::log::logger_fn(log_fn);
+    }
+    return true;
+}
+
+bool init_unit_test()
+{
+    return setup_env(boost::unit_test::framework::master_test_suite().argc,
+                     boost::unit_test::framework::master_test_suite().argv);
+}


### PR DESCRIPTION
Write wsrep-lib logging facility output from unit tests into file.
Make travis build test step a bit more verbose.