### PR TITLE
Error voting support

### DIFF
--- a/dbsim/db_high_priority_service.hpp
+++ b/dbsim/db_high_priority_service.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -35,7 +35,8 @@ namespace db
         const wsrep::transaction& transaction() const override;
         int adopt_transaction(const wsrep::transaction&) override;
         int apply_write_set(const wsrep::ws_meta&,
-                            const wsrep::const_buffer&) override;
+                            const wsrep::const_buffer&,
+                            wsrep::mutable_buffer&) override;
         int append_fragment_and_commit(
             const wsrep::ws_handle&,
             const wsrep::ws_meta&, const wsrep::const_buffer&)
@@ -45,14 +46,17 @@ namespace db
         { return 0; }
         int commit(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
         int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
-        int apply_toi(const wsrep::ws_meta&, const wsrep::const_buffer&) override;
+        int apply_toi(const wsrep::ws_meta&, const wsrep::const_buffer&,
+                      wsrep::mutable_buffer&) override;
+        void adopt_apply_error(wsrep::mutable_buffer&) override;
         virtual void after_apply() override;
         void store_globals() override { }
         void reset_globals() override { }
         void switch_execution_context(wsrep::high_priority_service&) override
         { }
         int log_dummy_write_set(const wsrep::ws_handle&,
-                                const wsrep::ws_meta&) override;
+                                const wsrep::ws_meta&,
+                                wsrep::mutable_buffer&) override;
         virtual bool is_replaying() const override;
         void debug_crash(const char*) override { }
     private:
@@ -71,7 +75,7 @@ namespace db
         // After apply is empty for replayer to keep the transaction
         // context available for the client session after replaying
         // is over.
-        void after_apply() override { }
+        void after_apply() override {}
         bool is_replaying() const override { return true; }
     };
 

--- a/include/wsrep/buffer.hpp
+++ b/include/wsrep/buffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -38,13 +38,22 @@ namespace wsrep
             , size_(size)
         { }
 
+        const_buffer(const const_buffer& b)
+            : ptr_(b.ptr())
+            , size_(b.size())
+        { }
+
         const void* ptr() const { return ptr_; }
-        const void* data() const { return ptr_; }
+        const char* data() const { return static_cast<const char*>(ptr_); }
         size_t size() const { return size_; }
 
+        const_buffer& operator=(const const_buffer& b)
+        {
+            ptr_  = b.ptr();
+            size_ = b.size();
+            return *this;
+        }
     private:
-        // const_buffer(const const_buffer&);
-        // const_buffer& operator=(const const_buffer&);
         const void* ptr_;
         size_t size_;
     };
@@ -57,16 +66,36 @@ namespace wsrep
             : buffer_()
         { }
 
+        void resize(size_t s) { buffer_.resize(s); }
+
+        void clear()
+        {
+            // using swap to ensure deallocation
+            std::vector<char>().swap(buffer_);
+        }
+
         void push_back(const char* begin, const char* end)
         {
             buffer_.insert(buffer_.end(), begin, end);
         }
-        const char* data() const { return &buffer_[0]; }
+
+        template <class C> void push_back(const C& c)
+        {
+            std::copy(c.begin(), c.end(), std::back_inserter(buffer_));
+        }
+
         size_t size() const { return buffer_.size(); }
+        char* data() { return &buffer_[0]; }
+        const char* data() const { return &buffer_[0]; }
+
+        mutable_buffer& operator= (const mutable_buffer& other)
+        {
+            buffer_ = other.buffer_;
+            return *this;
+        }
     private:
         std::vector<char> buffer_;
     };
-
 }
 
 #endif // WSREP_BUFFER_HPP

--- a/include/wsrep/client_id.hpp
+++ b/include/wsrep/client_id.hpp
@@ -41,6 +41,10 @@ namespace wsrep
         {
             return (id_ < other.id_);
         }
+        bool operator==(const client_id& other) const
+        {
+            return (id_ == other.id_);
+        }
     private:
         type id_;
     };

--- a/include/wsrep/gtid.hpp
+++ b/include/wsrep/gtid.hpp
@@ -48,6 +48,13 @@ namespace wsrep
         {
             return undefined_;
         }
+        bool operator==(const gtid& other) const
+        {
+            return (
+                seqno_ == other.seqno_ &&
+                id_ == other.id_
+            );
+        }
     private:
         static const wsrep::gtid undefined_;
         wsrep::id id_;

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -56,6 +56,14 @@ namespace wsrep
         wsrep::transaction_id transaction_id() const
         { return transaction_id_; }
         wsrep::client_id client_id() const { return client_id_; }
+        bool operator==(const stid& other) const
+        {
+            return (
+                server_id_ == other.server_id_ &&
+                transaction_id_ == other.transaction_id_ &&
+                client_id_ == other.client_id_
+            );
+        }
     private:
         wsrep::id server_id_;
         wsrep::transaction_id transaction_id_;
@@ -84,6 +92,13 @@ namespace wsrep
 
         void* opaque() const { return opaque_; }
 
+        bool operator==(const ws_handle& other) const
+        {
+            return (
+                transaction_id_ == other.transaction_id_ &&
+                opaque_ == other.opaque_
+            );
+        }
     private:
         wsrep::transaction_id transaction_id_;
         void* opaque_;
@@ -134,9 +149,21 @@ namespace wsrep
             return stid_.transaction_id();
         }
 
+        bool ordered() const { return !gtid_.is_undefined(); }
+
         wsrep::seqno depends_on() const { return depends_on_; }
 
         int flags() const { return flags_; }
+
+        bool operator==(const ws_meta& other) const
+        {
+            return (
+                gtid_ == other.gtid_ &&
+                stid_ == other.stid_ &&
+                depends_on_ == other.depends_on_ &&
+                flags_ == other.flags_
+            );
+        }
     private:
         wsrep::gtid gtid_;
         wsrep::stid stid_;
@@ -300,7 +327,8 @@ namespace wsrep
         virtual enum status commit_order_enter(const wsrep::ws_handle&,
                                                const wsrep::ws_meta&) = 0;
         virtual int commit_order_leave(const wsrep::ws_handle&,
-                                       const wsrep::ws_meta&) = 0;
+                                       const wsrep::ws_meta&,
+                                       const wsrep::mutable_buffer& err) = 0;
         virtual int release(wsrep::ws_handle&) = 0;
 
         /**
@@ -325,7 +353,8 @@ namespace wsrep
         /**
          * Leave total order isolation critical section
          */
-        virtual enum status leave_toi(wsrep::client_id) = 0;
+        virtual enum status leave_toi(wsrep::client_id,
+                                      const wsrep::mutable_buffer& err) = 0;
 
         /**
          * Perform a causal read on cluster.

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -788,13 +788,18 @@ wsrep::wsrep_provider_v26::commit_order_enter(
         wsrep_->commit_order_enter(wsrep_, cwsh.native(), cwsm.native()));
 }
 
-int wsrep::wsrep_provider_v26::commit_order_leave(
+int
+wsrep::wsrep_provider_v26::commit_order_leave(
     const wsrep::ws_handle& ws_handle,
-    const wsrep::ws_meta& ws_meta)
+    const wsrep::ws_meta& ws_meta,
+    const wsrep::mutable_buffer& err)
 {
     const_ws_handle cwsh(ws_handle);
     const_ws_meta cwsm(ws_meta);
-    return (wsrep_->commit_order_leave(wsrep_, cwsh.native(), cwsm.native(), 0) != WSREP_OK);
+    wsrep_buf_t const err_buf = { err.data(), err.size() };
+    int ret(wsrep_->commit_order_leave(
+         wsrep_, cwsh.native(), cwsm.native(), &err_buf) != WSREP_OK);
+    return ret;
 }
 
 int wsrep::wsrep_provider_v26::release(wsrep::ws_handle& ws_handle)
@@ -851,10 +856,12 @@ wsrep::wsrep_provider_v26::enter_toi(
 }
 
 enum wsrep::provider::status
-wsrep::wsrep_provider_v26::leave_toi(wsrep::client_id client_id)
+wsrep::wsrep_provider_v26::leave_toi(wsrep::client_id client_id,
+                                     const wsrep::mutable_buffer& err)
 {
+    const wsrep_buf_t err_buf = { err.data(), err.size() };
     return map_return_value(wsrep_->to_execute_end(
-                                wsrep_, client_id.get(), 0));
+                                wsrep_, client_id.get(), &err_buf));
 }
 
 std::pair<wsrep::gtid, enum wsrep::provider::status>

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -64,7 +64,8 @@ namespace wsrep
         commit_order_enter(const wsrep::ws_handle&,
                            const wsrep::ws_meta&);
         int commit_order_leave(const wsrep::ws_handle&,
-                               const wsrep::ws_meta&);
+                               const wsrep::ws_meta&,
+                               const wsrep::mutable_buffer&);
         int release(wsrep::ws_handle&);
         enum wsrep::provider::status replay(const wsrep::ws_handle&,
                                             wsrep::high_priority_service*);
@@ -73,7 +74,8 @@ namespace wsrep
                                                const wsrep::const_buffer&,
                                                wsrep::ws_meta&,
                                                int);
-        enum wsrep::provider::status leave_toi(wsrep::client_id);
+        enum wsrep::provider::status leave_toi(wsrep::client_id,
+                                               const wsrep::mutable_buffer&);
         std::pair<wsrep::gtid, enum wsrep::provider::status>
         causal_read(int) const;
         enum wsrep::provider::status wait_for_gtid(const wsrep::gtid&, int) const;

--- a/test/mock_high_priority_service.cpp
+++ b/test/mock_high_priority_service.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -19,6 +19,7 @@
 
 #include "mock_high_priority_service.hpp"
 #include "mock_server_state.hpp"
+#include <sstream>
 
 int wsrep::mock_high_priority_service::start_transaction(
     const wsrep::ws_handle& ws_handle, const wsrep::ws_meta& ws_meta)
@@ -34,13 +35,25 @@ int wsrep::mock_high_priority_service::adopt_transaction(
 }
 
 int wsrep::mock_high_priority_service::apply_write_set(
-    const wsrep::ws_meta&,
-    const wsrep::const_buffer&)
+    const wsrep::ws_meta& meta,
+    const wsrep::const_buffer&,
+    wsrep::mutable_buffer& err)
 {
     assert(client_state_->toi_meta().seqno().is_undefined());
     assert(client_state_->transaction().state() == wsrep::transaction::s_executing ||
            client_state_->transaction().state() == wsrep::transaction::s_replaying);
-    return (fail_next_applying_ ? 1 : 0);
+    if (fail_next_applying_)
+    {
+        std::ostringstream os;
+        os << "failed " << meta;
+        err.push_back(os.str());
+        assert(err.size() > 0);
+        return 1;
+    }
+    else
+    {
+        return 0;
+    };
 }
 
 int wsrep::mock_high_priority_service::commit(
@@ -69,14 +82,29 @@ int wsrep::mock_high_priority_service::rollback(
 }
 
 int wsrep::mock_high_priority_service::apply_toi(const wsrep::ws_meta&,
-                                                 const wsrep::const_buffer&)
+                                                 const wsrep::const_buffer&,
+                                                 wsrep::mutable_buffer&)
 {
     assert(client_state_->transaction().active() == false);
     assert(client_state_->toi_meta().seqno().is_undefined() == false);
     return (fail_next_toi_ ? 1 : 0);
 }
 
+void wsrep::mock_high_priority_service::adopt_apply_error(
+    wsrep::mutable_buffer& err)
+{
+    client_state_->adopt_apply_error(err);
+}
+
 void wsrep::mock_high_priority_service::after_apply()
 {
     client_state_->after_applying();
+}
+
+int wsrep::mock_high_priority_service::log_dummy_write_set(
+    const wsrep::ws_handle&,
+    const wsrep::ws_meta&,
+    wsrep::mutable_buffer& err)
+{
+    return err.size() > 0;
 }

--- a/test/mock_high_priority_service.hpp
+++ b/test/mock_high_priority_service.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -47,7 +47,8 @@ namespace wsrep
         { return client_state_->transaction(); }
         int adopt_transaction(const wsrep::transaction&) WSREP_OVERRIDE;
         int apply_write_set(const wsrep::ws_meta&,
-                            const wsrep::const_buffer&) WSREP_OVERRIDE;
+                            const wsrep::const_buffer&,
+                            wsrep::mutable_buffer&) WSREP_OVERRIDE;
         int append_fragment_and_commit(
             const wsrep::ws_handle&,
             const wsrep::ws_meta&,
@@ -59,21 +60,23 @@ namespace wsrep
             WSREP_OVERRIDE;
         int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&) WSREP_OVERRIDE;
         int apply_toi(const wsrep::ws_meta&,
-                      const wsrep::const_buffer&) WSREP_OVERRIDE;
+                      const wsrep::const_buffer&,
+                      wsrep::mutable_buffer&) WSREP_OVERRIDE;
+        void adopt_apply_error(wsrep::mutable_buffer& err) WSREP_OVERRIDE;
         void after_apply() WSREP_OVERRIDE;
         void store_globals() WSREP_OVERRIDE { }
         void reset_globals() WSREP_OVERRIDE { }
         void switch_execution_context(wsrep::high_priority_service&)
             WSREP_OVERRIDE { }
         int log_dummy_write_set(const wsrep::ws_handle&,
-                                const wsrep::ws_meta&)
-            WSREP_OVERRIDE { return 0; }
+                                const wsrep::ws_meta&,
+                                wsrep::mutable_buffer&) WSREP_OVERRIDE;
         bool is_replaying() const WSREP_OVERRIDE { return replaying_; }
         void debug_crash(const char*) WSREP_OVERRIDE { /* Not in unit tests*/}
 
-        wsrep::mock_client_state* client_state()
+        wsrep::client_state& client_state()
         {
-            return client_state_;
+            return *client_state_;
         }
         bool do_2pc_;
         bool fail_next_applying_;

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -102,7 +102,7 @@ namespace wsrep
         {
             mock_high_priority_service* mhps(
                 static_cast<mock_high_priority_service*>(high_priority_service));
-            wsrep::mock_client* cs(static_cast<wsrep::mock_client*>(
+            wsrep::mock_client* cs(&static_cast<wsrep::mock_client&>(
                                        mhps->client_state()));
             cs->after_command_before_result();
             cs->after_command_after_result();

--- a/test/mock_storage_service.cpp
+++ b/test/mock_storage_service.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -239,6 +239,8 @@ BOOST_FIXTURE_TEST_CASE(server_state_applying_2pc,
 BOOST_FIXTURE_TEST_CASE(server_state_applying_1pc_rollback,
                         applying_server_fixture)
 {
+    /* make sure default success result is flipped to error_fatal */
+    ss.provider().commit_order_leave_result_ = wsrep::provider::success;
     hps.fail_next_applying_ = true;
     char buf[1] = { 1 };
     BOOST_REQUIRE(ss.on_apply(hps, ws_handle, ws_meta,
@@ -252,6 +254,8 @@ BOOST_FIXTURE_TEST_CASE(server_state_applying_1pc_rollback,
 BOOST_FIXTURE_TEST_CASE(server_state_applying_2pc_rollback,
                         applying_server_fixture)
 {
+    /* make sure default success result is flipped to error_fatal */
+    ss.provider().commit_order_leave_result_ = wsrep::provider::success;
     hps.do_2pc_ = true;
     hps.fail_next_applying_ = true;
     char buf[1] = { 1 };

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *

--- a/test/transaction_test_2pc.cpp
+++ b/test/transaction_test_2pc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *


### PR DESCRIPTION
Highlights:
     - populate and pass real error description buffer to provider in case of applying error
     - return 0 from server_state::on_apply() if error voting confirmed consistency
     - remove fragments and rollback after fragment applying failure
     - always release streaming applier on commit or rollback

MTR with master 4.x: https://jenkins.galeracluster.com:8443/job/mtr-galera-4.x-mariadb-10.4/767/consoleFull
MTR with updated 4.x: https://jenkins.galeracluster.com:8443/job/mtr-galera-4.x-mariadb-10.4/769/consoleFull