### PR TITLE
Minimize client_service interface for XA

### DIFF
--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -44,18 +44,6 @@ namespace db
             return 0;
         }
         void cleanup_transaction() override { }
-        bool is_xa () const override
-        {
-            return false;
-        }
-        bool is_xa_prepare() const override
-        {
-            return false;
-        }
-        std::string xid() const override
-        {
-            return "";
-        }
         size_t bytes_generated() const override
         {
             return 0;

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -74,24 +74,6 @@ namespace wsrep
         virtual void cleanup_transaction() = 0;
 
         //
-        // XA
-        //
-        /**
-         * Return true if the current transactions is XA
-         */
-        virtual bool is_xa() const = 0;
-
-        /**
-         * Return true if the current statement is XA PREPARE
-         */
-        virtual bool is_xa_prepare() const = 0;
-
-        /**
-         * Return a string representing the xid of the transaction
-         */
-        virtual std::string xid() const = 0;
-
-        //
         // Streaming
         //
         /**

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -294,36 +294,6 @@ namespace wsrep
         }
 
         /**
-         * Restores the client's transaction to prepared state
-         *
-         * The purpose of this method is to restore transaction state
-         * during recovery of a prepared XA transaction.
-         */
-        int restore_prepared_transaction()
-        {
-            return transaction_.restore_to_prepared_state();
-        }
-
-        /**
-         * Terminate transaction with the given xid
-         *
-         * Sends a commit or rollback fragment to terminate the a
-         * transaction with the given xid. For the fragment to be
-         * sent, a streaming applier for the transaction must exist
-         * and the transaction must be in prepared state.
-         *
-         * @param xid the xid of the the transaction to terminate
-         * @param commit whether to send a commmit or rollback fragment
-         *
-         * @return Zero on success, non-zero on error. In case of error
-         *         the client_state's current_error is set
-         */
-        int commit_or_rollback_by_xid(const std::string& xid, bool commit)
-        {
-            return transaction_.commit_or_rollback_by_xid(xid, commit);
-        }
-
-        /**
          * Append a key into transaction write set.
          */
         int append_key(const wsrep::key& key)
@@ -509,6 +479,52 @@ namespace wsrep
             cond_.notify_all();
         }
         /** @} */
+
+        //
+        // XA
+        //
+        /**
+         * Assign transaction external id.
+         *
+         * Other than storing the xid, the transaction is marked as XA.
+         * This should be called when XA transaction is started.
+         *
+         * @param xid transaction id
+         */
+        void assign_xid(const std::string& xid)
+        {
+            transaction_.assign_xid(xid);
+        }
+
+        /**
+         * Restores the client's transaction to prepared state
+         *
+         * The purpose of this method is to restore transaction state
+         * during recovery of a prepared XA transaction.
+         */
+        int restore_xid(std::string& xid)
+        {
+            return transaction_.restore_to_prepared_state(xid);
+        }
+
+        /**
+         * Terminate transaction with the given xid
+         *
+         * Sends a commit or rollback fragment to terminate a
+         * transaction with the given xid. For the fragment to be
+         * sent, a streaming applier for the transaction must exist
+         * and the transaction must be in prepared state.
+         *
+         * @param xid the xid of the the transaction to terminate
+         * @param commit whether to send a commmit or rollback fragment
+         *
+         * @return Zero on success, non-zero on error. In case of error
+         *         the client_state's current_error is set
+         */
+        int commit_or_rollback_by_xid(const std::string& xid, bool commit)
+        {
+            return transaction_.commit_or_rollback_by_xid(xid, commit);
+        }
 
         //
         // BF aborting

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -62,8 +62,6 @@ namespace wsrep
             : wsrep::client_service()
             , is_autocommit_()
             , do_2pc_()
-            , is_xa_()
-            , is_xa_prepare_()
               // , fail_next_applying_()
               // , fail_next_toi_()
             , bf_abort_during_wait_()
@@ -131,21 +129,6 @@ namespace wsrep
 
         void cleanup_transaction() WSREP_OVERRIDE { }
 
-        bool is_xa() const WSREP_OVERRIDE
-        {
-            return is_xa_;
-        }
-
-        bool is_xa_prepare() const WSREP_OVERRIDE
-        {
-            return is_xa_prepare_;
-        }
-
-        std::string xid() const WSREP_OVERRIDE
-        {
-            return "";
-        }
-
         size_t bytes_generated() const WSREP_OVERRIDE
         {
             return bytes_generated_;
@@ -197,8 +180,6 @@ namespace wsrep
         //
         bool is_autocommit_;
         bool do_2pc_;
-        bool is_xa_;
-        bool is_xa_prepare_;
         // bool fail_next_applying_;
         // bool fail_next_toi_;
         bool bf_abort_during_wait_;


### PR DESCRIPTION
Remove methods `is_xa()`, `is_xa_prepare()`, and `xid()` from
client_service interface. Instead, transactions are explicitly
assigned their xid, through at start of XA.