### PR TITLE
GCC 4.7 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,29 @@ matrix:
       env: MATRIX_EVAL="CC=gcc-4.4 CXX=g++-4.4 TYPE=RelWithDebInfo STRICT=OFF UNIT_TESTS=OFF ASAN=OFF DBSIM=OFF"
     - os: linux
       dist: trusty
+      name: "GCC 4.7 Debug"
+      addons:
+        apt:
+          packages:
+            - cmake
+            - libboost-test-dev
+            - gcc-4.7
+            - g++-4.7
+      env: MATRIX_EVAL="CC=gcc-4.7 CXX=g++-4.7 TYPE=Debug STRICT=OFF UNIT_TESTS=ON DBSIM=OFF"
+    - os: linux
+      dist: trusty
+      name: "GCC 4.7 RelWithDebInfo"
+      addons:
+        apt:
+          packages:
+            - cmake
+            - libboost-test-dev
+            - gcc-4.7
+            - g++-4.7
+      env: MATRIX_EVAL="CC=gcc-4.7 CXX=g++-4.7 TYPE=RelWithDebInfo STRICT=OFF UNIT_TESTS=ON DBSIM=OFF"
+
+    - os: linux
+      dist: trusty
       name: "GCC 4.8 Debug"
       addons:
         apt:

--- a/include/wsrep/compiler.hpp
+++ b/include/wsrep/compiler.hpp
@@ -37,13 +37,17 @@
  */
 
 
+#if __cplusplus >= 201103L && !(__GNUC__ == 4 && __GNUG_MINOR__ < 8)
+#define WSREP_NORETURN [[noreturn]]
+#else
+#define WSREP_NORETURN __attribute__((noreturn))
+#endif // __cplusplus >= 201103L && !(__GNUC__ == 4 && __GNUG_MINOR__ < 8)
+
 #if __cplusplus >= 201103L
 #define WSREP_NOEXCEPT noexcept
-#define WSREP_NORETURN [[noreturn]]
 #define WSREP_OVERRIDE override
 #else
 #define WSREP_NOEXCEPT
-#define WSREP_NORETURN __attribute__((noreturn))
 #define WSREP_OVERRIDE
 #endif // __cplusplus >= 201103L
 #define WSREP_UNUSED __attribute__((unused))

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1067,9 +1067,15 @@ int wsrep::transaction::commit_or_rollback_by_xid(const wsrep::xid& xid,
         return 1;
     }
 
-    int flags(commit ?
-              wsrep::provider::flag::commit :
-              wsrep::provider::flag::rollback);
+    int flags(0);
+    if (commit)
+    {
+        flags = wsrep::provider::flag::commit;
+    }
+    else
+    {
+        flags = wsrep::provider::flag::rollback;
+    }
     flags = flags | wsrep::provider::flag::pa_unsafe;
     wsrep::stid stid(sa->transaction().server_id(),
                      sa->transaction().id(),


### PR DESCRIPTION
Added GCC 4.7 into Travis build matrix, fixed compilation issues with GCC 4.7.