### PR TITLE
Incorrect assertion and state handling in after_replay().

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -640,8 +640,6 @@ namespace wsrep
         /**
          * Clone enough state from another transaction so that replaing will
          * be possible with a transaction contained in this client state.
-         * Method after_replay() must be used to inject the state after
-         * replaying back to this client state.
          *
          * @param transaction Transaction which is to be replied in this
          *                    client state
@@ -650,16 +648,6 @@ namespace wsrep
         {
             // assert(mode_ == m_high_priority);
             transaction_.clone_for_replay(transaction);
-        }
-
-        /**
-         * Copy state from another transaction context after replay.
-         *
-         * @param transaction Transaction which was used for replaying.
-         */
-        void after_replay(const wsrep::transaction& transaction)
-        {
-            transaction_.after_replay(transaction);
         }
 
         /** @name Non-transactional operations */

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -199,8 +199,6 @@ namespace wsrep
 
         void clone_for_replay(const wsrep::transaction& other);
 
-        void after_replay(const wsrep::transaction& other);
-
         bool bf_aborted() const
         {
             return (bf_abort_client_state_ != 0);
@@ -248,6 +246,7 @@ namespace wsrep
         int append_sr_keys_for_commit();
         int release_commit_order(wsrep::unique_lock<wsrep::mutex>&);
         void streaming_rollback(wsrep::unique_lock<wsrep::mutex>&);
+        int replay(wsrep::unique_lock<wsrep::mutex>&);
         void clear_fragments();
         void cleanup();
         void debug_log_state(const char*) const;


### PR DESCRIPTION
If the transaction fails during replay because of certification
failure, the provider will return control to applier without
terminating the transaction and transaction remains in
s_replaying.

Fixed transaction::after_statement() to handle the state changes
correctly if certification failure is returned from replay.
Replaying was extracted to separate private method from
after_statement(). Removed transaction::after_replay() as it
seems now unnecessary and it bypassed state change sanity checks.

Allowed replaying -> committed transaction transition to handle
the situation where DBMS allocates a new context and client_state
to do the replay.