### PR TITLE
Set server position after local certification failure

### DIFF
--- a/dbsim/db_server_service.cpp
+++ b/dbsim/db_server_service.cpp
@@ -144,6 +144,12 @@ wsrep::gtid db::server_service::get_position(wsrep::client_service&)
     return server_.storage_engine().get_position();
 }
 
+void db::server_service::set_position(wsrep::client_service&,
+                                      const wsrep::gtid& gtid)
+{
+    return server_.storage_engine().store_position(gtid);
+}
+
 void db::server_service::log_state_change(
     enum wsrep::server_state::state prev_state,
     enum wsrep::server_state::state current_state)

--- a/dbsim/db_server_service.hpp
+++ b/dbsim/db_server_service.hpp
@@ -53,6 +53,7 @@ namespace db
         wsrep::view get_view(wsrep::client_service&, const wsrep::id&)
             override;
         wsrep::gtid get_position(wsrep::client_service&) override;
+        void set_position(wsrep::client_service&, const wsrep::gtid&) override;
         void log_state_change(enum wsrep::server_state::state,
                               enum wsrep::server_state::state) override;
         int wait_committing_transactions(int) override;

--- a/include/wsrep/server_service.hpp
+++ b/include/wsrep/server_service.hpp
@@ -180,6 +180,18 @@ namespace wsrep
          */
         virtual wsrep::gtid get_position(
             wsrep::client_service& client_service) = 0;
+
+        /**
+         * Set the current replication position of the server
+         * storage.
+         *
+         * @param client_service Reference to client_service
+         * @param gtid Reference to position to be set
+         */
+        virtual void set_position(
+            wsrep::client_service& client_service,
+            const wsrep::gtid& gtid) = 0;
+
         /**
          * Log a state change event.
          *

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -758,8 +758,13 @@ int wsrep::transaction::release_commit_order(
     lock.unlock();
     int ret(provider().commit_order_enter(ws_handle_, ws_meta_));
     lock.lock();
-    return ret || provider().commit_order_leave(ws_handle_, ws_meta_,
-                                                apply_error_buf_);
+    if (!ret)
+    {
+        server_service_.set_position(client_service_, ws_meta_.gtid());
+        ret = provider().commit_order_leave(ws_handle_, ws_meta_,
+                                            apply_error_buf_);
+    }
+    return ret;
 }
 
 int wsrep::transaction::after_statement()

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -156,6 +156,13 @@ namespace wsrep
         {
             return position_;
         }
+
+        void set_position(wsrep::client_service&,
+                          const wsrep::gtid& gtid) WSREP_OVERRIDE
+        {
+            position_ = gtid;
+        }
+
         void log_state_change(enum wsrep::server_state::state,
                               enum wsrep::server_state::state)
             WSREP_OVERRIDE


### PR DESCRIPTION
After a local certification failure, commit order is released without
the setting the current position in DBMS. Which results in diverging
positions between provider and DBMS, if clean shutdown happens right
after local certification failure.
This patch add method set_position() to server_service class. So that
wsrep-lib can instruct DBMS to set the current position after local
certification failure releases commit order.