### PR TITLE
Fix various spelling errors

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,4 +26,5 @@ Authors from Codership Oy:
 
 Other contributors:
 
+ * Otto Kekäläinen <otto@kekalainen.net>
  [add name and email/username above this line, but leave this line intact]

--- a/include/wsrep/server_service.hpp
+++ b/include/wsrep/server_service.hpp
@@ -231,7 +231,7 @@ namespace wsrep
          * @param gtid A GTID denoting the current replication position
          * @param bypass Boolean bypass flag.
          *
-         * @return Zero if the SST transfer was succesfully started,
+         * @return Zero if the SST transfer was successfully started,
          *         non-zero otherwise.
          */
         virtual int start_sst(const std::string& sst_request,

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -163,7 +163,7 @@ namespace wsrep
             s_connected,
             /** Server is receiving SST */
             s_joiner,
-            /** Server has received SST succesfully but has not synced
+            /** Server has received SST successfully but has not synced
               with rest of the cluster yet. */
             s_joined,
             /** Server is donating state snapshot transfer */

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -93,7 +93,7 @@ namespace wsrep
         { return (ws_meta_.seqno().is_undefined() == false); }
 
         /**
-         * Return true if any fragments have been succesfully certified
+         * Return true if any fragments have been successfully certified
          * for the transaction.
          */
         bool is_streaming() const
@@ -104,7 +104,7 @@ namespace wsrep
         /**
          * Return number of fragments certified for current statement.
          *
-         * This counts fragments which have been succesfully certified
+         * This counts fragments which have been successfully certified
          * since the construction of object or last after_statement()
          * call.
          *

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -600,7 +600,7 @@ wsrep::seqno wsrep::server_state::desync_and_pause()
         // Desync may give transient error if the provider cannot
         // communicate with the rest of the cluster. However, this
         // error can be tolerated because if the provider can be
-        // paused succesfully below.
+        // paused successfully below.
         WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
                         wsrep::log::debug_level_server_state,
                         "Failed to desync server before pause");
@@ -753,7 +753,7 @@ void wsrep::server_state::sst_received(wsrep::client_service& cs,
                  * logged view. */
                 std::ostringstream msg;
                 msg << "SST script passed bogus GTID: " << gtid
-                    << ". Preceeding view GTID: " << v.state_id();
+                    << ". Preceding view GTID: " << v.state_id();
                 throw wsrep::runtime_error(msg.str());
             }
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -962,7 +962,7 @@ bool wsrep::transaction::bf_abort(
                 WSREP_LOG_DEBUG(client_state_.debug_log_level(),
                                 wsrep::log::debug_level_transaction,
                                 "Seqno " << bf_seqno
-                                << " succesfully BF aborted " << id_
+                                << " successfully BF aborted " << id_
                                 << " victim_seqno " << victim_seqno);
                 bf_abort_state_ = state_at_enter;
                 state(lock, s_must_abort);
@@ -1733,8 +1733,8 @@ int wsrep::transaction::certify_commit(
         client_state_.override_error(wsrep::e_error_during_commit, cert_ret);
         break;
     case wsrep::provider::error_bf_abort:
-        // Transaction was replicated succesfully and it was either
-        // certified succesfully or the result of certifying is not
+        // Transaction was replicated successfully and it was either
+        // certified successfully or the result of certifying is not
         // yet known. Therefore the transaction must roll back
         // and go through replay either to replay and commit the whole
         // transaction or to determine failed certification status.

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -452,7 +452,7 @@ BOOST_FIXTURE_TEST_CASE(
 }
 
 // Error or shutdown happens during catchup phase after receiving
-// SST succesfully.
+// SST successfully.
 BOOST_FIXTURE_TEST_CASE(
     server_state_sst_first_error_on_joined,
     sst_first_server_fixture)

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -71,7 +71,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc, T,
     // Establish default read view
     BOOST_REQUIRE(0 == cc.assign_read_view(NULL));
 
-    // Verify that the commit can be succesfully executed in separate command
+    // Verify that the commit can be successfully executed in separate command
     BOOST_REQUIRE(cc.after_statement() == 0);
     cc.after_command_before_result();
     cc.after_command_after_result();


### PR DESCRIPTION
e.g.
- succesfully -> successfully
- preceeding -> preceding