### PR TITLE
Avoid concurrent rollback from rollbacker and rollback fragment

### DIFF
--- a/include/wsrep/compiler.hpp
+++ b/include/wsrep/compiler.hpp
@@ -32,8 +32,10 @@
  *                  it, otherwise "__attribute__((noreturn))".
  * WSREP_OVERRIDE - Set to "override" if the compiler supports it, otherwise
  *                  left empty.
- * WSREP_UNUSED - Can be used to mark variables which may be present in
- *                debug builds but not in release builds.
+ * WSREP_UNUSED   - Can be used to mark variables which may be present in
+ *                  debug builds but not in release builds.
+ * WSREP_WARN_UNUSED_RESULT - Mark function or methods so that a warning is
+ *                            raised if its return value is unused.
  */
 
 
@@ -51,3 +53,4 @@
 #define WSREP_OVERRIDE
 #endif // __cplusplus >= 201103L
 #define WSREP_UNUSED __attribute__((unused))
+#define WSREP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -255,8 +255,19 @@ namespace wsrep
             const wsrep::transaction_id&,
             wsrep::high_priority_service*);
 
-        void stop_streaming_applier(
-            const wsrep::id&, const wsrep::transaction_id&);
+        /**
+         * Stop the streaming applier matching server server and transaction ids
+         *
+         * If a corresponding streaming applier is found, it is stopped,
+         * and returned to the caller.
+         *
+         * @return pointer to the stopped streaming applier
+         *         nullptr if the streaming applier was already stopped
+         */
+        WSREP_WARN_UNUSED_RESULT
+        wsrep::high_priority_service* stop_streaming_applier(
+            const wsrep::id&,
+            const wsrep::transaction_id&);
 
         /**
          * Find a streaming applier matching server and transaction ids

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -1170,7 +1170,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_rollback,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1217,7 +1217,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_non_commit,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1248,7 +1248,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_commit,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 
@@ -1405,7 +1405,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
-    sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
+    BOOST_REQUIRE(sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     server_service.release_high_priority_service(hps);
 }
 


### PR DESCRIPTION
This patch avoids the situation where rollbacker is fired and
a rollback fragment attempt to rollback the same transaction
concurrently. This happens when a high priority streaming transaction
is BF aborted by TOI, and at the same time the transaction managed to
replicate one more fragment which fails certification. Failed
certification results in rollback fragment, which may be delivered
and processes before the streaming applier is stopped by in bf_abort().
The fix consists in changing rollback fragment processing so that
it stops the corresponding streaming applier right away.
Should a rollback fragment and BF abort happen concurrently, we now
expect that only one of the two manages stop the affected streaming
applier. So that the transaction is either rolled back by rollback
fragment or rollbacker thread in DBMS.