### PR TITLE
Support for detaching prepared XA transactions

### DIFF
--- a/dbsim/db_client_service.hpp
+++ b/dbsim/db_client_service.hpp
@@ -60,11 +60,33 @@ namespace db
         int remove_fragments() override { return 0; }
         int bf_rollback() override;
         void will_replay() override { }
+        void signal_replayed() override { }
         void wait_for_replayers(wsrep::unique_lock<wsrep::mutex>&) override { }
         enum wsrep::provider::status replay()
             override;
 
+        enum wsrep::provider::status replay_unordered() override
+        {
+            return wsrep::provider::success;
+        }
+
         void emergency_shutdown() override { ::abort(); }
+
+        enum wsrep::provider::status commit_by_xid() override
+        {
+            return wsrep::provider::success;
+        }
+
+        bool is_explicit_xa() override
+        {
+            return false;
+        }
+
+        bool is_xa_rollback() override
+        {
+            return false;
+        }
+
         void debug_sync(const char*) override { }
         void debug_crash(const char*) override { }
     private:

--- a/include/wsrep/buffer.hpp
+++ b/include/wsrep/buffer.hpp
@@ -66,6 +66,10 @@ namespace wsrep
             : buffer_()
         { }
 
+        mutable_buffer(const mutable_buffer& b)
+            : buffer_(b.buffer_)
+        { }
+
         void resize(size_t s) { buffer_.resize(s); }
 
         void clear()
@@ -110,6 +114,11 @@ namespace wsrep
         {
             buffer_ = other.buffer_;
             return *this;
+        }
+
+        bool operator==(const mutable_buffer& other) const
+        {
+          return buffer_ == other.buffer_;
         }
     private:
         std::vector<char> buffer_;

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -184,13 +184,13 @@ namespace wsrep
          */
         virtual enum wsrep::provider::status commit_by_xid() = 0;
 
-        /*
-          Returns true if the client has an ongoing XA transaction.
-          This method is used to determine when to cleanup the
-          corresponding wsrep-lib transaction object.
-          This method should return false when the XA transaction
-          is over, and the wsrep-lib transaction object can be
-          cleaned up.
+        /**
+         * Returns true if the client has an ongoing XA transaction.
+         * This method is used to determine when to cleanup the
+         * corresponding wsrep-lib transaction object.
+         * This method should return false when the XA transaction
+         * is over, and the wsrep-lib transaction object can be
+         * cleaned up.
          */
         virtual bool is_explicit_xa() = 0;
 

--- a/include/wsrep/client_service.hpp
+++ b/include/wsrep/client_service.hpp
@@ -146,6 +146,11 @@ namespace wsrep
         virtual void will_replay() = 0;
 
         /**
+         * Signal that replay is done.
+         */
+        virtual void signal_replayed() = 0;
+
+        /**
          * Replay the current transaction. The implementation must put
          * the caller Client Context into applying mode and call
          * client_state::replay().
@@ -156,6 +161,13 @@ namespace wsrep
         virtual enum wsrep::provider::status replay() = 0;
 
         /**
+         * Replay the current transaction. This is used for replaying
+         * prepared XA transactions, which are BF aborted but not
+         * while orderding commit / rollback.
+         */
+        virtual enum wsrep::provider::status replay_unordered() = 0;
+
+        /**
          * Wait until all replaying transactions have been finished
          * replaying.
          *
@@ -163,6 +175,32 @@ namespace wsrep
          * handled internally by wsrep-lib.
          */
         virtual void wait_for_replayers(wsrep::unique_lock<wsrep::mutex>&) = 0;
+
+        //
+        // XA
+        //
+        /**
+         * Send a commit by xid
+         */
+        virtual enum wsrep::provider::status commit_by_xid() = 0;
+
+        /*
+          Returns true if the client has an ongoing XA transaction.
+          This method is used to determine when to cleanup the
+          corresponding wsrep-lib transaction object.
+          This method should return false when the XA transaction
+          is over, and the wsrep-lib transaction object can be
+          cleaned up.
+         */
+        virtual bool is_explicit_xa() = 0;
+
+        /**
+         * Returns true if the currently executing command is
+         * a rollback for XA. This is used to avoid setting a
+         * a deadlock error rollback as it may be unexpected
+         * by the DBMS.
+         */
+        virtual bool is_xa_rollback() = 0;
 
         //
         // Debug interface

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -601,6 +601,8 @@ namespace wsrep
          */
         void xa_detach()
         {
+            assert(mode_ == m_local);
+            assert(state_ == s_none || state_ == s_exec);
             transaction_.xa_detach();
         }
 

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -589,6 +589,21 @@ namespace wsrep
             return transaction_.commit_or_rollback_by_xid(xid, false);
         }
 
+        /**
+         * Detach a prepared XA transaction
+         *
+         * This method cleans up a local XA transaction in prepared state
+         * and converts it to high priority mode.
+         * This can be used to handle the case where the client of a XA
+         * transaction disconnects, and the transaction must not rollback.
+         * After this call, a different client may later attempt to terminate
+         * the transaction by calling method commit_by_xid() or rollback_by_xid().
+         */
+        void xa_detach()
+        {
+            transaction_.xa_detach();
+        }
+
         //
         // BF aborting
         //

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -604,6 +604,23 @@ namespace wsrep
             transaction_.xa_detach();
         }
 
+        /**
+         * Replay a XA transaction
+         *
+         * Replay a XA transaction that is in s_idle state.
+         * This may happen if the transaction is BF aborted
+         * between prepare and commit.
+         * Since the victim is idle, this method can be called
+         * by the BF aborter or the backround rollbacker.
+         */
+        void xa_replay()
+        {
+            assert(mode_ == m_local);
+            assert(state_ == s_idle);
+            wsrep::unique_lock<wsrep::mutex> lock(mutex_);
+            transaction_.xa_replay(lock);
+        }
+
         //
         // BF aborting
         //

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -146,6 +146,8 @@ namespace wsrep
 
         void xa_detach();
 
+        int xa_replay(wsrep::unique_lock<wsrep::mutex>&);
+
         bool pa_unsafe() const { return pa_unsafe_; }
         void pa_unsafe(bool pa_unsafe) { pa_unsafe_ = pa_unsafe; }
 

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -125,17 +125,17 @@ namespace wsrep
 
         bool is_xa() const
         {
-            return !xid_.empty();
+            return !xid_.is_null();
         }
 
         void assign_xid(const wsrep::xid& xid)
         {
             assert(active());
-            assert(xid_.empty());
+            assert(!is_xa());
             xid_ = xid;
         }
 
-        const wsrep::xid xid() const
+        const wsrep::xid& xid() const
         {
             return xid_;
         }
@@ -143,6 +143,8 @@ namespace wsrep
         int restore_to_prepared_state(const wsrep::xid& xid);
 
         int commit_or_rollback_by_xid(const wsrep::xid& xid, bool commit);
+
+        void xa_detach();
 
         bool pa_unsafe() const { return pa_unsafe_; }
         void pa_unsafe(bool pa_unsafe) { pa_unsafe_ = pa_unsafe; }

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -128,12 +128,7 @@ namespace wsrep
             return !xid_.is_null();
         }
 
-        void assign_xid(const wsrep::xid& xid)
-        {
-            assert(active());
-            assert(!is_xa());
-            xid_ = xid;
-        }
+        void assign_xid(const wsrep::xid& xid);
 
         const wsrep::xid& xid() const
         {

--- a/include/wsrep/xid.hpp
+++ b/include/wsrep/xid.hpp
@@ -22,6 +22,7 @@
 
 #include <iosfwd>
 #include "buffer.hpp"
+#include "exception.hpp"
 
 namespace wsrep
 {
@@ -42,6 +43,10 @@ namespace wsrep
             , bqual_len_(bqual_len)
             , data_()
         {
+            if (gtrid_len_ > 64 || bqual_len_ > 64)
+            {
+                throw wsrep::runtime_error("maximum wsrep::xid size exceeded");
+            }
             const long len = gtrid_len_ + bqual_len_;
             if (len > 0)
             {
@@ -64,6 +69,8 @@ namespace wsrep
         void clear()
         {
             format_id_ = -1;
+            gtrid_len_ = 0;
+            bqual_len_ = 0;
             data_.clear();
         }
 

--- a/include/wsrep/xid.hpp
+++ b/include/wsrep/xid.hpp
@@ -21,23 +21,80 @@
 #define WSREP_XID_HPP
 
 #include <iosfwd>
-#include <string>
+#include "buffer.hpp"
 
 namespace wsrep
 {
     class xid
     {
     public:
-        xid() : xid_() { }
-        xid(const std::string& str) : xid_(str) { }
-        xid(const char* s) : xid_(s) { }
-        bool empty() const { return xid_.empty(); }
-        void clear() { xid_.clear(); }
-        bool operator==(const xid& other) const { return xid_ == other.xid_; }
+        xid()
+            : format_id_(-1)
+            , gtrid_len_(0)
+            , bqual_len_(0)
+            , data_()
+        { }
+
+        xid(long format_id, long gtrid_len,
+            long bqual_len, const char* data)
+            : format_id_(format_id)
+            , gtrid_len_(gtrid_len)
+            , bqual_len_(bqual_len)
+            , data_()
+        {
+            const long len = gtrid_len_ + bqual_len_;
+            if (len > 0)
+            {
+                data_.push_back(data, data + len);
+            }
+        }
+
+        xid(const xid& xid)
+            : format_id_(xid.format_id_)
+            , gtrid_len_(xid.gtrid_len_)
+            , bqual_len_(xid.bqual_len_)
+            , data_(xid.data_)
+        { }
+
+        bool is_null() const
+        {
+            return format_id_ == -1;
+        }
+
+        void clear()
+        {
+            format_id_ = -1;
+            data_.clear();
+        }
+
+        xid& operator= (const xid& other)
+        {
+            format_id_ = other.format_id_;
+            gtrid_len_ = other.gtrid_len_;
+            bqual_len_ = other.bqual_len_;
+            data_ = other.data_;
+            return *this;
+        }
+
+        bool operator==(const xid& other) const
+        {
+            if (format_id_ != other.format_id_ ||
+                gtrid_len_ != other.gtrid_len_ ||
+                bqual_len_ != other.bqual_len_ ||
+                data_.size() != other.data_.size())
+            {
+                return false;
+            }
+            return data_ == other.data_;
+        }
+
         friend std::string to_string(const wsrep::xid& xid);
         friend std::ostream& operator<<(std::ostream& os, const wsrep::xid& xid);
-    private:
-        std::string xid_;
+    protected:
+        long format_id_;
+        long gtrid_len_;
+        long bqual_len_;
+        mutable_buffer data_;
     };
 
     std::string to_string(const wsrep::xid& xid);

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -50,7 +50,9 @@ void wsrep::client_state::close()
     debug_log_state("close: enter");
     state(lock, s_quitting);
     lock.unlock();
-    if (transaction_.active())
+    if (transaction_.active() &&
+        (mode_ != m_local ||
+         transaction_.state() != wsrep::transaction::s_prepared))
     {
         client_service_.bf_rollback();
         transaction_.after_statement();

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -1429,9 +1429,10 @@ void wsrep::server_state::recover_streaming_appliers_if_not_recovered(
 class transaction_state_cmp
 {
 public:
-    transaction_state_cmp(const enum wsrep::transaction::state s) : state_(s)
-    { }
-    bool operator()(std::pair<const wsrep::client_id, wsrep::client_state*>& vt) const
+    transaction_state_cmp(const enum wsrep::transaction::state s)
+        : state_(s) { }
+    bool operator()(const std::pair<wsrep::client_id,
+                    wsrep::client_state*>& vt) const
     {
         return vt.second->transaction().state() == state_;
     }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1071,6 +1071,13 @@ void wsrep::transaction::clone_for_replay(const wsrep::transaction& other)
     state_ = s_replaying;
 }
 
+void wsrep::transaction::assign_xid(const wsrep::xid& xid)
+{
+    assert(active());
+    assert(!is_xa());
+    xid_ = xid;
+}
+
 int wsrep::transaction::restore_to_prepared_state(const wsrep::xid& xid)
 {
     wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex_);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1108,6 +1108,7 @@ int wsrep::transaction::restore_to_prepared_state(const wsrep::xid& xid)
 int wsrep::transaction::commit_or_rollback_by_xid(const wsrep::xid& xid,
                                                   bool commit)
 {
+    debug_log_state("commit_or_rollback_by_xid enter");
     wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex_);
     wsrep::server_state& server_state(client_state_.server_state());
     wsrep::high_priority_service* sa(server_state.find_streaming_applier(xid));
@@ -1140,6 +1141,7 @@ int wsrep::transaction::commit_or_rollback_by_xid(const wsrep::xid& xid,
                            flags,
                            meta));
 
+    int ret;
     if (cert_ret == wsrep::provider::success)
     {
         if (commit)
@@ -1153,7 +1155,7 @@ int wsrep::transaction::commit_or_rollback_by_xid(const wsrep::xid& xid,
             state(lock, s_aborting);
             state(lock, s_aborted);
         }
-        return 0;
+        ret = 0;
     }
     else
     {
@@ -1162,8 +1164,10 @@ int wsrep::transaction::commit_or_rollback_by_xid(const wsrep::xid& xid,
         wsrep::log_error() << "Failed to commit_or_rollback_by_xid,"
                            << " xid: " << xid
                            << " error: " << cert_ret;
-        return 1;
+        ret = 1;
     }
+    debug_log_state("commit_or_rollback_by_xid leave");
+    return ret;
 }
 
 void wsrep::transaction::xa_detach()

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -422,7 +422,6 @@ int wsrep::transaction::after_prepare(
         if (state() == s_must_abort)
         {
             assert(client_state_.mode() == wsrep::client_state::m_local);
-            client_service_.will_replay();
             state(lock, s_must_replay);
             ret = 1;
         }
@@ -470,7 +469,6 @@ int wsrep::transaction::before_commit()
             if (certified() ||
                 (is_xa() && is_streaming()))
             {
-                client_service_.will_replay();
                 state(lock, s_must_replay);
             }
             else
@@ -509,7 +507,6 @@ int wsrep::transaction::before_commit()
             case wsrep::provider::success:
                 break;
             case wsrep::provider::error_bf_abort:
-                client_service_.will_replay();
                 if (state() != s_must_abort)
                 {
                     state(lock, s_must_abort);
@@ -695,7 +692,6 @@ int wsrep::transaction::before_rollback()
         case s_must_abort:
             if (certified())
             {
-                client_service_.will_replay();
                 state(lock, s_must_replay);
             }
             else
@@ -1023,7 +1019,6 @@ bool wsrep::transaction::bf_abort(
             // rollbacker gets control.
             if (is_xa() && state_at_enter == s_prepared)
             {
-                client_service_.will_replay();
                 state(lock, s_must_replay);
                 client_state_.set_rollbacker_active(true);
             }
@@ -1642,7 +1637,6 @@ int wsrep::transaction::certify_commit(
     {
         if (is_xa() && state() == s_must_abort)
         {
-            client_service_.will_replay();
             state(lock, s_must_replay);
         }
         return 1;
@@ -1768,7 +1762,6 @@ int wsrep::transaction::certify_commit(
         {
             if (is_xa())
             {
-                client_service_.will_replay();
                 state(lock, s_must_replay);
             }
             client_state_.override_error(wsrep::e_deadlock_error);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -484,7 +484,6 @@ int wsrep::transaction::before_commit()
 
         if (ret == 0 && state() == s_prepared)
         {
-            assert(state() == s_prepared);
             ret = certify_commit(lock);
             assert((ret == 0 && state() == s_committing) ||
                    (state() == s_must_abort ||

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -823,7 +823,6 @@ int wsrep::transaction::release_commit_order(
 int wsrep::transaction::after_statement()
 {
     int ret(0);
-    client_service_.debug_sync("wsrep_after_statement_enter");
     wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex());
     debug_log_state("after_statement_enter");
     assert(client_state_.mode() == wsrep::client_state::m_local);

--- a/src/xid.cpp
+++ b/src/xid.cpp
@@ -22,10 +22,10 @@
 
 std::string wsrep::to_string(const wsrep::xid& xid)
 {
-    return xid.xid_;
+    return std::string(xid.data_.data(), xid.data_.size());
 }
 
 std::ostream& wsrep::operator<<(std::ostream& os, const wsrep::xid& xid)
 {
-    return os << xid.xid_;
+    return os << to_string(xid);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(wsrep-lib_test
   transaction_test_2pc.cpp
   transaction_test_xa.cpp
   view_test.cpp
+  xid_test.cpp
   wsrep-lib_test.cpp
   )
 

--- a/test/client_state_fixture.hpp
+++ b/test/client_state_fixture.hpp
@@ -51,6 +51,35 @@ namespace
         const wsrep::transaction& tc;
     };
 
+    struct replicating_two_clients_fixture_sync_rm
+    {
+        replicating_two_clients_fixture_sync_rm()
+            : server_service(sc)
+            , sc("s1", wsrep::server_state::rm_sync, server_service)
+            , cc1(sc, wsrep::client_id(1),
+                  wsrep::client_state::m_local)
+            , cc2(sc, wsrep::client_id(2),
+                  wsrep::client_state::m_local)
+            , tc(cc1.transaction())
+        {
+            sc.mock_connect();
+            cc1.open(cc1.id());
+            BOOST_REQUIRE(cc1.before_command() == 0);
+            BOOST_REQUIRE(cc1.before_statement() == 0);
+            cc2.open(cc2.id());
+            BOOST_REQUIRE(cc2.before_command() == 0);
+            BOOST_REQUIRE(cc2.before_statement() == 0);
+            // Verify initial state
+            BOOST_REQUIRE(tc.active() == false);
+            BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
+        }
+        wsrep::mock_server_service server_service;
+        wsrep::mock_server_state sc;
+        wsrep::mock_client cc1;
+        wsrep::mock_client cc2;
+        const wsrep::transaction& tc;
+    };
+
     struct replicating_client_fixture_async_rm
     {
         replicating_client_fixture_async_rm()

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -74,6 +74,7 @@ namespace wsrep
             , client_state_(client_state)
             , will_replay_called_()
             , replays_()
+            , unordered_replays_()
             , aborts_()
         { }
 
@@ -108,6 +109,7 @@ namespace wsrep
 
         enum wsrep::provider::status replay_unordered() WSREP_OVERRIDE
         {
+            unordered_replays_++;
             return wsrep::provider::success;
         }
 
@@ -221,11 +223,13 @@ namespace wsrep
         //
         bool will_replay_called() const { return will_replay_called_; }
         size_t replays() const { return replays_; }
+        size_t unordered_replays() const { return unordered_replays_; }
         size_t aborts() const { return aborts_; }
     private:
         wsrep::mock_client_state& client_state_;
         bool will_replay_called_;
         size_t replays_;
+        size_t unordered_replays_;
         size_t aborts_;
     };
 

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -102,7 +102,14 @@ namespace wsrep
 
         void will_replay() WSREP_OVERRIDE { will_replay_called_ = true; }
 
+        void signal_replayed() WSREP_OVERRIDE { }
+
         enum wsrep::provider::status replay() WSREP_OVERRIDE;
+
+        enum wsrep::provider::status replay_unordered() WSREP_OVERRIDE
+        {
+            return wsrep::provider::success;
+        }
 
         void wait_for_replayers(
             wsrep::unique_lock<wsrep::mutex>& lock)
@@ -152,6 +159,21 @@ namespace wsrep
 
         void store_globals() WSREP_OVERRIDE { }
         void reset_globals() WSREP_OVERRIDE { }
+
+        enum wsrep::provider::status commit_by_xid() WSREP_OVERRIDE
+        {
+            return wsrep::provider::success;
+        }
+
+        bool is_explicit_xa() WSREP_OVERRIDE
+        {
+            return false;
+        }
+
+        bool is_xa_rollback() WSREP_OVERRIDE
+        {
+            return false;
+        }
 
         void debug_sync(const char* sync_point) WSREP_OVERRIDE
         {

--- a/test/mock_high_priority_service.cpp
+++ b/test/mock_high_priority_service.cpp
@@ -37,6 +37,10 @@ int wsrep::mock_high_priority_service::adopt_transaction(
     const wsrep::transaction& transaction)
 {
     client_state_->adopt_transaction(transaction);
+    if (transaction.state() == wsrep::transaction::s_prepared)
+    {
+        client_state_->restore_xid(transaction.xid());
+    }
     return 0;
 }
 

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -104,7 +104,6 @@ namespace wsrep
             }
             if (rolls_back_transaction(flags))
             {
-                assert(0);
                 ++rollback_fragments_;
             }
 

--- a/test/transaction_test_xa.cpp
+++ b/test/transaction_test_xa.cpp
@@ -7,8 +7,10 @@
 BOOST_FIXTURE_TEST_CASE(transaction_xa,
                         replicating_client_fixture_sync_rm)
 {
+    wsrep::xid xid(1, 9, 0, "test xid");
+
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
-    cc.assign_xid("test xid");
+    cc.assign_xid(xid);
 
     BOOST_REQUIRE(tc.active());
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
@@ -52,8 +54,10 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa,
 BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
                         applying_client_fixture)
 {
+    wsrep::xid xid(1, 9, 0, "test xid");
+
     start_transaction(wsrep::transaction_id(1), wsrep::seqno(1));
-    cc.assign_xid("test xid");
+    cc.assign_xid(xid);
 
     BOOST_REQUIRE(cc.before_prepare() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_preparing);
@@ -85,8 +89,11 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
 BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
                         streaming_client_fixture_byte)
 {
+    wsrep::xid xid(1, 9, 0, "test xid");
+
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
-    cc.assign_xid("test xid");
+    cc.assign_xid(xid);
+
     cc.bytes_generated_ = 1;
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);

--- a/test/xid_test.cpp
+++ b/test/xid_test.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Codership Oy <info@codership.com>
+ *
+ * This file is part of wsrep-lib.
+ *
+ * Wsrep-lib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Wsrep-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "wsrep/xid.hpp"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(xid_test_is_null)
+{
+    wsrep::xid null_xid;
+    BOOST_REQUIRE(null_xid.is_null());
+    wsrep::xid test_xid(1,0,0,nullptr);
+    BOOST_REQUIRE(!test_xid.is_null());
+}
+
+BOOST_AUTO_TEST_CASE(xid_test_equal)
+{
+    wsrep::xid a(1,1,1,"ab");
+    wsrep::xid b(1,1,1,"ab");
+    BOOST_REQUIRE(a == b);
+}
+
+BOOST_AUTO_TEST_CASE(xid_test_null_equal)
+{
+    wsrep::xid a;
+    wsrep::xid b;
+    BOOST_REQUIRE(a == b);
+    BOOST_REQUIRE(a.is_null());
+}
+
+BOOST_AUTO_TEST_CASE(xid_test_not_equal)
+{
+    wsrep::xid a(1,1,0,"a");
+    wsrep::xid b(1,0,1,"a");
+    wsrep::xid c(-1,1,0,"a");
+    wsrep::xid d(1,1,0,"b");
+    BOOST_REQUIRE(!(a == b));
+    BOOST_REQUIRE(!(a == c));
+    BOOST_REQUIRE(!(a == d));
+}
+
+BOOST_AUTO_TEST_CASE(xid_clear)
+{
+    wsrep::xid null_xid;
+    wsrep::xid to_clear(1, 1, 0, "a");
+    to_clear.clear();
+    BOOST_REQUIRE(to_clear.is_null());
+    BOOST_REQUIRE(null_xid == to_clear);
+}
+
+BOOST_AUTO_TEST_CASE(xid_to_string)
+{
+    wsrep::xid null_xid;
+    std::stringstream null_xid_str;
+    null_xid_str << null_xid;
+    BOOST_REQUIRE(null_xid_str.str() == "");
+
+    wsrep::xid test_xid(1,4,0,"test");
+    std::string xid_str(to_string(test_xid));
+    BOOST_REQUIRE(xid_str == "test");
+}
+
+static bool exception_check(const wsrep::runtime_error&)
+{
+    return true;
+}
+
+BOOST_AUTO_TEST_CASE(xid_too_big)
+{
+    std::string s(65,'a');
+    BOOST_REQUIRE_EXCEPTION(wsrep::xid a(1, 65, 0, s.c_str()),
+                            wsrep::runtime_error, exception_check);
+    BOOST_REQUIRE_EXCEPTION(wsrep::xid b(1, 0, 65, s.c_str()),
+                            wsrep::runtime_error, exception_check);
+}


### PR DESCRIPTION
Add support for detaching XA transactions. This is useful for handling
the case where the DBMS client has a transaction in prepared state and
disconnects. Before disconnect, the DBMS calls the newly introduced
client_state::xa_detach(), to cleanup the local transaction and
convert it to a high priority transaction. The DBMS may later attempt
to terminate the transaction through client_state::commit_by_xid() or
client_state::rollback_by_xid().