### PR TITLE
Some methods in wsrep-lib still hide/ignore return codes from provider

### DIFF
--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -186,16 +186,7 @@ namespace wsrep
 
     std::string flags_to_string(int flags);
 
-    static inline
-    std::ostream& operator<<(std::ostream& os, const wsrep::ws_meta& ws_meta)
-    {
-        os << "gtid: " << ws_meta.gtid()
-           << " server_id: " << ws_meta.server_id()
-           << " client_id: " << ws_meta.client_id()
-           << " trx_id: " << ws_meta.transaction_id()
-           << " flags: " << ws_meta.flags() << " (" << wsrep::flags_to_string(ws_meta.flags()) << ")";
-        return os;
-    }
+    std::ostream& operator<<(std::ostream& os, const wsrep::ws_meta& ws_meta);
 
     // Abstract interface for provider implementations
     class provider
@@ -249,6 +240,8 @@ namespace wsrep
             /** Unknown error code from the provider */
             error_unknown
         };
+
+        static std::string to_string(enum status);
 
         struct flag
         {
@@ -385,9 +378,9 @@ namespace wsrep
          * Return last committed GTID.
          */
         virtual wsrep::gtid last_committed_gtid() const = 0;
-        virtual int sst_sent(const wsrep::gtid&, int) = 0;
-        virtual int sst_received(const wsrep::gtid&, int) = 0;
-        virtual int enc_set_key(const wsrep::const_buffer& key) = 0;
+        virtual enum status sst_sent(const wsrep::gtid&, int) = 0;
+        virtual enum status sst_received(const wsrep::gtid&, int) = 0;
+        virtual enum status enc_set_key(const wsrep::const_buffer& key) = 0;
         virtual std::vector<status_variable> status() const = 0;
         virtual void reset_status() = 0;
 

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -25,7 +25,6 @@
 #include <dlfcn.h>
 #include <memory>
 
-
 wsrep::provider* wsrep::provider::make_provider(
     wsrep::server_state& server_state,
     const std::string& provider_spec,
@@ -42,7 +41,7 @@ wsrep::provider* wsrep::provider::make_provider(
         wsrep::log_error() << "Failed to create a new provider '"
                            << provider_spec << "'"
                            << " with options '" << provider_options
-                           << "':" << e.what();
+                           << "': " << e.what();
     }
     catch (...)
     {
@@ -52,6 +51,44 @@ wsrep::provider* wsrep::provider::make_provider(
                            << " with options '" << provider_options;
     }
     return 0;
+}
+
+std::string
+wsrep::provider::to_string(enum wsrep::provider::status const val)
+{
+    switch(val)
+    {
+    case success:
+        return "Success";
+    case error_warning:
+        return "Warning";
+    case error_transaction_missing:
+        return "Transaction not registered with provider";
+    case error_certification_failed:
+        return "Certification failed";
+    case error_bf_abort:
+        return "Transaction was BF aborted";
+    case error_size_exceeded:
+        return "Transaction size exceeded";
+    case error_connection_failed:
+        return "Not connected to Primary Component";
+    case error_provider_failed:
+        return "Provider in bad state, needs to be reinitialized.";
+    case error_fatal:
+        return "Fatal error, must abort.";
+    case error_not_implemented:
+        return "Function not implemented";
+    case error_not_allowed:
+        return "Operation not allowed";
+    case error_unknown:
+        return "Unknown error";
+    }
+
+    assert(0);
+
+    std::ostringstream os;
+    os << "Invalid error code: " << val;
+    return os.str();
 }
 
 std::string wsrep::provider::capability::str(int caps)
@@ -119,4 +156,15 @@ std::string wsrep::flags_to_string(int flags)
     std::string ret(oss.str());
     if (ret.size() > 3) ret.erase(ret.size() - 3);
     return ret;
+}
+
+std::ostream& wsrep::operator<<(std::ostream& os, const wsrep::ws_meta& ws_meta)
+{
+    os <<  "gtid: "      << ws_meta.gtid()
+       << " server_id: " << ws_meta.server_id()
+       << " client_id: " << ws_meta.client_id()
+       << " trx_id: "    << ws_meta.transaction_id()
+       << " flags: "     << ws_meta.flags()
+       << " (" << wsrep::flags_to_string(ws_meta.flags()) << ")";
+    return os;
 }

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -82,9 +82,9 @@ namespace wsrep
         causal_read(int) const;
         enum wsrep::provider::status wait_for_gtid(const wsrep::gtid&, int) const;
         wsrep::gtid last_committed_gtid() const;
-        int sst_sent(const wsrep::gtid&,int);
-        int sst_received(const wsrep::gtid& gtid, int);
-        int enc_set_key(const wsrep::const_buffer& key);
+        enum wsrep::provider::status sst_sent(const wsrep::gtid&, int);
+        enum wsrep::provider::status sst_received(const wsrep::gtid& gtid, int);
+        enum wsrep::provider::status enc_set_key(const wsrep::const_buffer& key);
         std::vector<status_variable> status() const;
         void reset_status();
         std::string options() const;

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -276,11 +276,16 @@ namespace wsrep
         { return wsrep::provider::success; }
         wsrep::gtid last_committed_gtid() const WSREP_OVERRIDE
         { return wsrep::gtid(); }
-        int sst_sent(const wsrep::gtid&, int) WSREP_OVERRIDE { return 0; }
-        int sst_received(const wsrep::gtid&, int) WSREP_OVERRIDE { return 0; }
+        enum wsrep::provider::status sst_sent(const wsrep::gtid&, int)
+            WSREP_OVERRIDE
+        { return wsrep::provider::success; }
+        enum wsrep::provider::status sst_received(const wsrep::gtid&, int)
+            WSREP_OVERRIDE
+        { return wsrep::provider::success; }
 
-        int enc_set_key(const wsrep::const_buffer&) WSREP_OVERRIDE 
-        { return 0; }
+        enum wsrep::provider::status enc_set_key(const wsrep::const_buffer&)
+            WSREP_OVERRIDE
+        { return wsrep::provider::success; }
 
         std::vector<status_variable> status() const WSREP_OVERRIDE
         {


### PR DESCRIPTION
which complicates diagnostics and debugging.

Don't ignore provider return codes and more verbose error logging for
sst_sent(), sst_received(), set_encryption_key() methods

Refs codership/wsrep-lib#127