### PR TITLE
Added aborted parameter for set_position() method

### DIFF
--- a/dbsim/db_server_service.cpp
+++ b/dbsim/db_server_service.cpp
@@ -145,7 +145,8 @@ wsrep::gtid db::server_service::get_position(wsrep::client_service&)
 }
 
 void db::server_service::set_position(wsrep::client_service&,
-                                      const wsrep::gtid& gtid)
+                                      const wsrep::gtid& gtid,
+				      bool)
 {
     return server_.storage_engine().store_position(gtid);
 }

--- a/dbsim/db_server_service.hpp
+++ b/dbsim/db_server_service.hpp
@@ -53,7 +53,7 @@ namespace db
         wsrep::view get_view(wsrep::client_service&, const wsrep::id&)
             override;
         wsrep::gtid get_position(wsrep::client_service&) override;
-        void set_position(wsrep::client_service&, const wsrep::gtid&) override;
+      void set_position(wsrep::client_service&, const wsrep::gtid&, bool) override;
         void log_state_change(enum wsrep::server_state::state,
                               enum wsrep::server_state::state) override;
         int wait_committing_transactions(int) override;

--- a/include/wsrep/server_service.hpp
+++ b/include/wsrep/server_service.hpp
@@ -190,7 +190,8 @@ namespace wsrep
          */
         virtual void set_position(
             wsrep::client_service& client_service,
-            const wsrep::gtid& gtid) = 0;
+            const wsrep::gtid& gtid,
+	    bool aborted) = 0;
 
         /**
          * Log a state change event.

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -760,7 +760,8 @@ int wsrep::transaction::release_commit_order(
     lock.lock();
     if (!ret)
     {
-        server_service_.set_position(client_service_, ws_meta_.gtid());
+        server_service_.set_position(client_service_, ws_meta_.gtid(),
+                                     (state() == s_aborted));
         ret = provider().commit_order_leave(ws_handle_, ws_meta_,
                                             apply_error_buf_);
     }

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -158,7 +158,8 @@ namespace wsrep
         }
 
         void set_position(wsrep::client_service&,
-                          const wsrep::gtid& gtid) WSREP_OVERRIDE
+                          const wsrep::gtid& gtid,
+                          bool) WSREP_OVERRIDE
         {
             position_ = gtid;
         }


### PR DESCRIPTION
This is need to tell that the transaction, for which we are about to record GTID checkpoint has aborted. We have to record monotonic sequence of GTID's in DBMS, and transactions, which fail in certification have also consumed one GTID, and thus have to record their GTID although they are aborting.