### PR TITLE
codership/wsrep-lib#135 Fix wrong assertion in before_command().

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -117,8 +117,6 @@ int wsrep::client_state::before_command()
     {
         if (transaction_.state() == wsrep::transaction::s_must_abort)
         {
-            assert(server_state_.rollback_mode() ==
-                   wsrep::server_state::rm_async);
             override_error(wsrep::e_deadlock_error);
             lock.unlock();
             client_service_.bf_rollback();

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -970,6 +970,38 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.active() == false);
 }
 
+// Check the case where BF abort happens between client calls to
+// wait_rollback_complete_and_acquire_ownership()
+// and before before_command().
+BOOST_FIXTURE_TEST_CASE(
+    transaction_1pc_bf_abort_after_acquire_before_before_command_sync_rm,
+    replicating_client_fixture_sync_rm)
+{
+    cc.start_transaction(wsrep::transaction_id(1));
+    BOOST_REQUIRE(tc.active());
+    cc.after_statement();
+    BOOST_REQUIRE(cc.state() == wsrep::client_state::s_exec);
+    cc.after_command_before_result();
+    BOOST_REQUIRE(cc.state() == wsrep::client_state::s_result);
+    cc.after_command_after_result();
+    BOOST_REQUIRE(cc.state() == wsrep::client_state::s_idle);
+    cc.wait_rollback_complete_and_acquire_ownership();
+    BOOST_REQUIRE(cc.state() == wsrep::client_state::s_exec);
+    // As the control is now on client, the BF abort must just change
+    // the state to s_must_abort.
+    wsrep_test::bf_abort_unordered(cc);
+    BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_abort);
+    BOOST_REQUIRE(tc.active());
+    BOOST_REQUIRE(cc.before_command() == 1);
+    BOOST_REQUIRE(tc.active() == false);
+    BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
+    cc.after_command_before_result();
+    BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
+    cc.after_command_after_result();
+    BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
+    BOOST_REQUIRE(tc.active() == false);
+}
+
 BOOST_FIXTURE_TEST_CASE(
     transaction_1pc_bf_abort_after_after_command_after_result_async_rm,
     replicating_client_fixture_async_rm)


### PR DESCRIPTION
codership/wsrep-lib#135 Fix wrong assertion in before_command().
    
An assertion
    
  `server_state_.rollback_mode() == wsrep::server_state::rm_async`
    
fired in `client_state::before_command()` if a BF abort happened
between calls to wait_rollback_complete_and_acquire_ownership()
and before_command().
    
This commit adds a test to reproduce the assertion and verify
the correct behavior, as well as removes the incorrect assertion
to fix the issue.
