### PR TITLE
Check existence if dl library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
 endif()
 
 include(CheckIncludeFile)
+include(CheckLibraryExists)
 
 # Options
 
@@ -92,6 +93,14 @@ endif()
 # Set up include directories
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/wsrep-API")
+
+# Find libraries.
+CHECK_LIBRARY_EXISTS(dl dlopen "" WSREP_LIB_HAVE_LIBDL)
+if (WSREP_LIB_HAVE_LIBDL)
+  set(WSREP_LIB_LIBDL "dl")
+else()
+  set(WSREP_LIB_LIBDL "")
+endif()
 
 if (WSREP_LIB_WITH_UNIT_TESTS)
   find_package(Boost 1.54.0 REQUIRED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,4 +19,4 @@ add_library(wsrep-lib
   transaction.cpp
   uuid.cpp
   wsrep_provider_v26.cpp)
-target_link_libraries(wsrep-lib wsrep_api_v26 pthread dl)
+target_link_libraries(wsrep-lib wsrep_api_v26 pthread ${WSREP_LIB_LIBDL})


### PR DESCRIPTION
All platforms do not have dl library, but dlopen() and friends
are included in libc.

Check existence of dl lib and store into WSREP_LIB_LIBDL if found.