### PR TITLE
Introduced WSREP_ASSERT() for public headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ endif()
 # Enable extra libstdc++ assertions with debug build.
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions("-D_GLIBCXX_ASSERTIONS")
+  add_definitions("-DWSREP_LIB_HAVE_DEBUG")
 else()
   # Make sure that NDEBUG is enabled in release builds even
   # if the parent project does not define it.

--- a/dbsim/db_client_service.cpp
+++ b/dbsim/db_client_service.cpp
@@ -21,6 +21,8 @@
 #include "db_high_priority_service.hpp"
 #include "db_client.hpp"
 
+#include <cassert>
+
 db::client_service::client_service(db::client& client)
     : wsrep::client_service()
     , client_(client)

--- a/dbsim/db_storage_engine.cpp
+++ b/dbsim/db_storage_engine.cpp
@@ -33,7 +33,7 @@ void db::storage_engine::transaction::start(db::client* cc)
 void db::storage_engine::transaction::apply(
     const wsrep::transaction& transaction)
 {
-    assert(cc_);
+    WSREP_ASSERT(cc_);
     se_.bf_abort_some(transaction);
 }
 

--- a/include/wsrep/assert.hpp
+++ b/include/wsrep/assert.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2019 Codership Oy <info@codership.com>
+ *
+ * This file is part of wsrep-lib.
+ *
+ * Wsrep-lib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Wsrep-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/** @file assert.hpp
+ *
+ * Assert macro to be used in header files which may be included
+ * by the application. The macro WSREP_ASSERT() is independent of
+ * definition of NDEBUG and is effective only with debug builds.
+ *
+ * In order to enable WSREP_ASSERT() define WSREP_LIB_HAVE_DEBUG.
+ *
+ * The reason for this macro is to make assertions in header files
+ * independent of application preprocessor options.
+ */
+
+#ifndef WSREP_ASSERT_HPP
+#define WSREP_ASSERT_HPP
+
+#if defined(WSREP_LIB_HAVE_DEBUG)
+#include <cassert>
+#define WSREP_ASSERT(expr) assert(expr)
+#else
+#define WSREP_ASSERT(expr)
+#endif // WSREP_LIB_HAVE_DEBUG
+
+#endif // WSREP_ASSERT_HPP

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -31,6 +31,7 @@
 #ifndef WSREP_CLIENT_STATE_HPP
 #define WSREP_CLIENT_STATE_HPP
 
+#include "assert.hpp"
 #include "server_state.hpp"
 #include "server_service.hpp"
 #include "provider.hpp"
@@ -166,7 +167,7 @@ namespace wsrep
          */
         virtual ~client_state()
         {
-            assert(transaction_.active() == false);
+            WSREP_ASSERT(transaction_.active() == false);
         }
 
         /** @name Client session handling */
@@ -270,7 +271,7 @@ namespace wsrep
          */
         void after_applying()
         {
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(mode_ == m_high_priority);
             transaction_.after_applying();
         }
 
@@ -286,7 +287,7 @@ namespace wsrep
         int start_transaction(const wsrep::transaction_id& id)
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.start_transaction(id);
         }
 
@@ -304,8 +305,8 @@ namespace wsrep
          */
         int assign_read_view(const wsrep::gtid* const gtid = NULL)
         {
-            assert(mode_ == m_local);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(mode_ == m_local);
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.assign_read_view(gtid);
         }
 
@@ -318,8 +319,8 @@ namespace wsrep
          */
         int append_key(const wsrep::key& key)
         {
-            assert(mode_ == m_local);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(mode_ == m_local);
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.append_key(key);
         }
 
@@ -332,8 +333,8 @@ namespace wsrep
          */
         int append_keys(const wsrep::key_array& keys)
         {
-            assert(mode_ == m_local || mode_ == m_toi);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(mode_ == m_local || mode_ == m_toi);
+            WSREP_ASSERT(state_ == s_exec);
             for (auto i(keys.begin()); i != keys.end(); ++i)
             {
                 if (transaction_.append_key(*i))
@@ -349,8 +350,8 @@ namespace wsrep
          */
         int append_data(const wsrep::const_buffer& data)
         {
-            assert(mode_ == m_local);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(mode_ == m_local);
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.append_data(data);
         }
 
@@ -363,8 +364,8 @@ namespace wsrep
          */
         int after_row()
         {
-            assert(mode_ == m_local);
-            assert(state_ == s_exec);
+            WSREP_ASSERT(mode_ == m_local);
+            WSREP_ASSERT(state_ == s_exec);
             return (transaction_.streaming_context().fragment_size() ?
                     transaction_.after_row() : 0);
         }
@@ -403,7 +404,7 @@ namespace wsrep
 
         void fragment_applied(wsrep::seqno seqno)
         {
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(mode_ == m_high_priority);
             transaction_.fragment_applied(seqno);
         }
 
@@ -423,7 +424,7 @@ namespace wsrep
                                  const wsrep::ws_meta& ws_meta,
                                  bool is_commit)
         {
-            assert(state_ == s_exec);
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.prepare_for_ordering(
                 ws_handle, ws_meta, is_commit);
         }
@@ -435,15 +436,15 @@ namespace wsrep
                               const wsrep::ws_meta& meta)
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(mode_ == m_high_priority);
             return transaction_.start_transaction(wsh, meta);
         }
 
         int next_fragment(const wsrep::ws_meta& meta)
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(mode_ == m_high_priority);
             return transaction_.next_fragment(meta);
         }
 
@@ -452,44 +453,44 @@ namespace wsrep
         int before_prepare()
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_exec);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.before_prepare(lock);
         }
 
         int after_prepare()
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_exec);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_exec);
             return transaction_.after_prepare(lock);
         }
 
         int before_commit()
         {
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_exec || mode_ == m_local);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_exec || mode_ == m_local);
             return transaction_.before_commit();
         }
 
         int ordered_commit()
         {
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_exec || mode_ == m_local);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_exec || mode_ == m_local);
             return transaction_.ordered_commit();
         }
 
         int after_commit()
         {
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_exec || mode_ == m_local);
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_exec || mode_ == m_local);
             return transaction_.after_commit();
         }
         /** @} */
         int before_rollback()
         {
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_idle ||
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_idle ||
                    state_ == s_exec ||
                    state_ == s_result ||
                    state_ == s_quitting);
@@ -498,8 +499,8 @@ namespace wsrep
 
         int after_rollback()
         {
-            assert(owning_thread_id_ == wsrep::this_thread::get_id());
-            assert(state_ == s_idle ||
+            WSREP_ASSERT(owning_thread_id_ == wsrep::this_thread::get_id());
+            WSREP_ASSERT(state_ == s_idle ||
                    state_ == s_exec ||
                    state_ == s_result ||
                    state_ == s_quitting);
@@ -600,7 +601,7 @@ namespace wsrep
         int bf_abort(wsrep::seqno bf_seqno)
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(mode_ == m_local || transaction_.is_streaming());
+            WSREP_ASSERT(mode_ == m_local || transaction_.is_streaming());
             return transaction_.bf_abort(lock, bf_seqno);
         }
         /**
@@ -611,7 +612,7 @@ namespace wsrep
         int total_order_bf_abort(wsrep::seqno bf_seqno)
         {
             wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            assert(mode_ == m_local || transaction_.is_streaming());
+            WSREP_ASSERT(mode_ == m_local || transaction_.is_streaming());
             return transaction_.total_order_bf_abort(lock, bf_seqno);
         }
 
@@ -624,7 +625,7 @@ namespace wsrep
          */
         void adopt_transaction(const wsrep::transaction& transaction)
         {
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(mode_ == m_high_priority);
             transaction_.adopt(transaction);
         }
 
@@ -633,7 +634,7 @@ namespace wsrep
          */
         void adopt_apply_error(wsrep::mutable_buffer& err)
         {
-            assert(mode_ == m_high_priority);
+            WSREP_ASSERT(mode_ == m_high_priority);
             transaction_.adopt_apply_error(err);
         }
 
@@ -646,7 +647,7 @@ namespace wsrep
          */
         void clone_transaction_for_replay(const wsrep::transaction& transaction)
         {
-            // assert(mode_ == m_high_priority);
+            // WSREP_ASSERT(mode_ == m_high_priority);
             transaction_.clone_for_replay(transaction);
         }
 
@@ -1115,7 +1116,7 @@ namespace wsrep
         virtual ~high_priority_context()
         {
             wsrep::unique_lock<wsrep::mutex> lock(client_.mutex_);
-            assert(client_.mode() == wsrep::client_state::m_high_priority);
+            WSREP_ASSERT(client_.mode() == wsrep::client_state::m_high_priority);
             client_.mode(lock, orig_mode_);
         }
     private:
@@ -1139,7 +1140,7 @@ namespace wsrep
         ~client_toi_mode()
         {
             wsrep::unique_lock<wsrep::mutex> lock(client_.mutex_);
-            assert(client_.mode() == wsrep::client_state::m_toi);
+            WSREP_ASSERT(client_.mode() == wsrep::client_state::m_toi);
             client_.mode(lock, orig_mode_);
         }
     private:

--- a/include/wsrep/lock.hpp
+++ b/include/wsrep/lock.hpp
@@ -20,9 +20,8 @@
 #ifndef WSREP_LOCK_HPP
 #define WSREP_LOCK_HPP
 
+#include "assert.hpp"
 #include "mutex.hpp"
-
-#include <cassert>
 
 namespace wsrep
 {
@@ -48,13 +47,13 @@ namespace wsrep
         void lock()
         {
             mutex_.lock();
-            assert(locked_ == false);
+            WSREP_ASSERT(locked_ == false);
             locked_ = true;
         }
 
         void unlock()
         {
-            assert(locked_);
+            WSREP_ASSERT(locked_);
             locked_ = false;
             mutex_.unlock();
         }

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -27,7 +27,6 @@
 #include "transaction_id.hpp"
 #include "compiler.hpp"
 
-#include <cassert>
 #include <cstring>
 
 #include <string>

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -82,6 +82,7 @@
 #ifndef WSREP_SERVER_STATE_HPP
 #define WSREP_SERVER_STATE_HPP
 
+#include "assert.hpp"
 #include "mutex.hpp"
 #include "condition_variable.hpp"
 #include "id.hpp"
@@ -553,7 +554,7 @@ namespace wsrep
         enum state state(wsrep::unique_lock<wsrep::mutex>&
                          lock WSREP_UNUSED) const
         {
-            assert(lock.owns_lock());
+            WSREP_ASSERT(lock.owns_lock());
             return state_;
         }
 

--- a/include/wsrep/sr_key_set.hpp
+++ b/include/wsrep/sr_key_set.hpp
@@ -20,6 +20,8 @@
 #ifndef WSREP_SR_KEY_SET_HPP
 #define WSREP_SR_KEY_SET_HPP
 
+#include "assert.hpp"
+
 #include <set>
 #include <map>
 
@@ -36,7 +38,7 @@ namespace wsrep
 
         void insert(const wsrep::key& key)
         {
-            assert(key.size() >= 2);
+            WSREP_ASSERT(key.size() >= 2);
             if (key.size() < 2)
             {
                 throw wsrep::runtime_error("Invalid key size");

--- a/include/wsrep/streaming_context.hpp
+++ b/include/wsrep/streaming_context.hpp
@@ -20,6 +20,7 @@
 #ifndef WSREP_STREAMING_CONTEXT_HPP
 #define WSREP_STREAMING_CONTEXT_HPP
 
+#include "assert.hpp"
 #include "compiler.hpp"
 #include "logger.hpp"
 #include "seqno.hpp"
@@ -84,7 +85,7 @@ namespace wsrep
                             wsrep::log::debug_level_streaming,
                             "Enabling streaming: "
                             << fragment_unit << " " << fragment_size);
-            assert(fragment_size > 0);
+            WSREP_ASSERT(fragment_size > 0);
             fragment_unit_ = fragment_unit;
             fragment_size_ = fragment_size;
         }
@@ -131,7 +132,7 @@ namespace wsrep
 
         void rolled_back(wsrep::transaction_id id)
         {
-            assert(rollback_replicated_for_ == wsrep::transaction_id::undefined());
+            WSREP_ASSERT(rollback_replicated_for_ == wsrep::transaction_id::undefined());
             rollback_replicated_for_ = id;
         }
 
@@ -193,8 +194,8 @@ namespace wsrep
 
         void check_fragment_seqno(wsrep::seqno seqno WSREP_UNUSED)
         {
-            assert(seqno.is_undefined() == false);
-            assert(fragments_.empty() || fragments_.back() < seqno);
+            WSREP_ASSERT(seqno.is_undefined() == false);
+            WSREP_ASSERT(fragments_.empty() || fragments_.back() < seqno);
         }
 
         size_t fragments_certified_;

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -21,6 +21,7 @@
 #ifndef WSREP_TRANSACTION_HPP
 #define WSREP_TRANSACTION_HPP
 
+#include "assert.hpp"
 #include "provider.hpp"
 #include "server_state.hpp"
 #include "transaction_id.hpp"
@@ -31,7 +32,6 @@
 #include "client_service.hpp"
 #include "xid.hpp"
 
-#include <cassert>
 #include <vector>
 
 namespace wsrep
@@ -130,8 +130,8 @@ namespace wsrep
 
         void assign_xid(const wsrep::xid& xid)
         {
-            assert(active());
-            assert(xid_.empty());
+            WSREP_ASSERT(active());
+            WSREP_ASSERT(xid_.empty());
             xid_ = xid;
         }
 
@@ -211,6 +211,7 @@ namespace wsrep
 
         int flags() const
         {
+            WSREP_ASSERT(0);
             return flags_;
         }
 

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -25,6 +25,8 @@
 #include <sstream>
 #include <iostream>
 
+#include <cassert>
+
 wsrep::provider& wsrep::client_state::provider() const
 {
     return server_state_.provider();

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -24,6 +24,7 @@
 
 #include <dlfcn.h>
 #include <memory>
+#include <cassert>
 
 wsrep::provider* wsrep::provider::make_provider(
     wsrep::server_state& server_state,

--- a/src/thread_service_v1.cpp
+++ b/src/thread_service_v1.cpp
@@ -24,6 +24,7 @@
 #include "v26/wsrep_thread_service.h"
 
 #include <dlfcn.h>
+#include <cassert>
 #include <cerrno>
 
 namespace wsrep_thread_service_v1

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -29,6 +29,8 @@
 #include <sstream>
 #include <memory>
 
+#include <cassert>
+
 namespace
 {
     class storage_service_deleter


### PR DESCRIPTION
Public headers may be compiled with different preprocessor
options than compilation units or private headers within a
project. Introduced a macro WSREP_ASSERT() to be mainly used in
public headers. The macro can be enabled by defining
WSREP_LIB_HAVE_DEBUG and is enabled by default for Debug type builds.