### PR TITLE
Unlock before releasing aborted transaction in provider.

### DIFF
--- a/include/wsrep/key.hpp
+++ b/include/wsrep/key.hpp
@@ -89,6 +89,7 @@ namespace wsrep
 
     typedef std::vector<wsrep::key> key_array;
 
+    std::ostream& operator<<(std::ostream&, enum wsrep::key::type);
     std::ostream& operator<<(std::ostream&, const wsrep::key&);
 }
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -39,6 +39,20 @@ namespace
     }
 }
 
+std::ostream& wsrep::operator<<(std::ostream& os,
+                                enum wsrep::key::type key_type)
+{
+    switch (key_type)
+    {
+    case wsrep::key::shared: os << "shared"; break;
+    case wsrep::key::reference: os << "reference"; break;
+    case wsrep::key::update: os << "update"; break;
+    case wsrep::key::exclusive: os << "exclusive"; break;
+    default: os << "unknown"; break;
+    }
+    return os;
+}
+
 std::ostream& wsrep::operator<<(std::ostream& os, const wsrep::key& key)
 {
     os << "type: " << key.type();

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -841,7 +841,9 @@ int wsrep::transaction::after_statement()
         {
             ret = release_commit_order(lock);
         }
+        lock.unlock();
         provider().release(ws_handle_);
+        lock.lock();
     }
 
     if (state() != s_executing && state() != s_prepared)

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1142,6 +1142,11 @@ void wsrep::transaction::state(
         state_hist_.erase(state_hist_.begin());
     }
     state_ = next_state;
+
+    if (state_ == s_must_replay)
+    {
+        client_service_.will_replay();
+    }
 }
 
 bool wsrep::transaction::abort_or_interrupt(
@@ -1531,7 +1536,6 @@ int wsrep::transaction::certify_commit(
             // We got BF aborted after succesful certification
             // and before acquiring client state lock. The trasaction
             // must be replayed.
-            client_service_.will_replay();
             state(lock, s_must_replay);
             break;
         default:
@@ -1557,7 +1561,6 @@ int wsrep::transaction::certify_commit(
         // yet known. Therefore the transaction must roll back
         // and go through replay either to replay and commit the whole
         // transaction or to determine failed certification status.
-        client_service_.will_replay();
         if (state() != s_must_abort)
         {
             state(lock, s_must_abort);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1821,5 +1821,5 @@ void wsrep::transaction::debug_log_key_append(const wsrep::key& key) const
                     "key_append: "
                     << "trx_id: "
                     << int64_t(id().get())
-                    << " append key: " << key);
+                    << " append key:\n" << key);
 }

--- a/test/mock_client_state.hpp
+++ b/test/mock_client_state.hpp
@@ -72,6 +72,7 @@ namespace wsrep
             , sync_point_action_()
             , bytes_generated_()
             , client_state_(client_state)
+            , will_replay_called_()
             , replays_()
             , aborts_()
         { }
@@ -98,10 +99,11 @@ namespace wsrep
                 return 0;
             }
         }
-        void will_replay() WSREP_OVERRIDE { }
 
-        enum wsrep::provider::status
-        replay() WSREP_OVERRIDE;
+        void will_replay() WSREP_OVERRIDE { will_replay_called_ = true; }
+
+        enum wsrep::provider::status replay() WSREP_OVERRIDE;
+
         void wait_for_replayers(
             wsrep::unique_lock<wsrep::mutex>& lock)
             WSREP_OVERRIDE
@@ -195,10 +197,12 @@ namespace wsrep
         //
         // Verifying the state
         //
+        bool will_replay_called() const { return will_replay_called_; }
         size_t replays() const { return replays_; }
         size_t aborts() const { return aborts_; }
     private:
         wsrep::mock_client_state& client_state_;
+        bool will_replay_called_;
         size_t replays_;
         size_t aborts_;
     };

--- a/test/transaction_test_2pc.cpp
+++ b/test/transaction_test_2pc.cpp
@@ -94,6 +94,7 @@ BOOST_FIXTURE_TEST_CASE(
     wsrep_test::bf_abort_ordered(cc);
     BOOST_REQUIRE(cc.after_prepare());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
+    BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.after_rollback() == 0);
@@ -124,6 +125,7 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_abort);
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
+    BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.after_statement() == 0);
@@ -152,6 +154,7 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_abort);
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
+    BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(tc.certified() == true);
     BOOST_REQUIRE(tc.ordered() == true);
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -183,6 +186,7 @@ BOOST_FIXTURE_TEST_CASE(
     sc.provider().commit_order_enter_result_ = wsrep::provider::error_bf_abort;
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
+    BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(tc.certified() == true);
     BOOST_REQUIRE(tc.ordered() == true);
     sc.provider().commit_order_enter_result_ = wsrep::provider::success;


### PR DESCRIPTION
Having aborted transaction holding a lock when releasing the
transaction in provider may cause a deadlock if:
- The transaction was BF aborted before it was known that the
  latest fragment was successfully replicated,
- Transaction was going to be released on provider side, but
  it waited for commit order,
- BF thread tried to grab lock for BF aborting, perhaps for
  second time.

As a fix, unlock the lock protecting victim transaction for
the duration of transaction release.