### PR TITLE
Introduce non-locking variant of client_state::cleanup()

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -193,6 +193,13 @@ namespace wsrep
          * The state is changed to s_none.
          */
         void cleanup();
+
+        /**
+         * Overload of cleanup() method which takes lock as argument.
+         * This method does not release the lock during execution, but
+         * the lock is needed for debug build sanity checks.
+         */
+        void cleanup(wsrep::unique_lock<wsrep::mutex>& lock);
         /** @} */
 
         /** @name Client command handling */

--- a/include/wsrep/condition_variable.hpp
+++ b/include/wsrep/condition_variable.hpp
@@ -74,7 +74,7 @@ namespace wsrep
         {
             if (pthread_cond_wait(
                     &cond_,
-                    reinterpret_cast<pthread_mutex_t*>(lock.mutex().native())))
+                    reinterpret_cast<pthread_mutex_t*>(lock.mutex()->native())))
             {
                 throw wsrep::runtime_error("Cond wait failed");
             }

--- a/include/wsrep/lock.hpp
+++ b/include/wsrep/lock.hpp
@@ -20,57 +20,12 @@
 #ifndef WSREP_LOCK_HPP
 #define WSREP_LOCK_HPP
 
-#include "mutex.hpp"
-
-#include <cassert>
+#include <mutex>
 
 namespace wsrep
 {
-    template <class M>
-    class unique_lock
-    {
-    public:
-        unique_lock(M& mutex)
-            : mutex_(mutex)
-            , locked_(false)
-        {
-            mutex_.lock();
-            locked_ = true;
-        }
-        ~unique_lock()
-        {
-            if (locked_)
-            {
-                unlock();
-            }
-        }
-
-        void lock()
-        {
-            mutex_.lock();
-            assert(locked_ == false);
-            locked_ = true;
-        }
-
-        void unlock()
-        {
-            assert(locked_);
-            locked_ = false;
-            mutex_.unlock();
-        }
-
-        bool owns_lock() const
-        {
-            return locked_;
-        }
-
-        M& mutex() { return mutex_; }
-    private:
-        unique_lock(const unique_lock&);
-        unique_lock& operator=(const unique_lock&);
-        M& mutex_;
-        bool locked_;
-    };
+    template <class C>
+    using unique_lock = std::unique_lock<C>;
 }
 
 #endif // WSREP_LOCK_HPP

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -69,6 +69,11 @@ void wsrep::client_state::close()
 void wsrep::client_state::cleanup()
 {
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
+    cleanup(lock);
+}
+
+void wsrep::client_state::cleanup(wsrep::unique_lock<wsrep::mutex>& lock)
+{
     debug_log_state("cleanup: enter");
     state(lock, s_none);
     debug_log_state("cleanup: leave");

--- a/src/thread_service_v1.cpp
+++ b/src/thread_service_v1.cpp
@@ -23,6 +23,7 @@
 #include "wsrep/logger.hpp"
 #include "v26/wsrep_thread_service.h"
 
+#include <cassert>
 #include <dlfcn.h>
 #include <cerrno>
 


### PR DESCRIPTION
The method takes already locked lock object as an argument.
The caller must ensure that the lock object owns the underlying mutex.

Replaced homegrown wsrep::unique_lock with type alias from
std::unique_lock.