### PR TITLE
Add prefix argument to logger callback.

### DIFF
--- a/include/wsrep/logger.hpp
+++ b/include/wsrep/logger.hpp
@@ -42,7 +42,8 @@ namespace wsrep
             debug,
             info,
             warning,
-            error
+            error,
+            unknown
         };
 
         enum debug_level
@@ -55,8 +56,12 @@ namespace wsrep
 
         /**
          * Signature for user defined logger callback function.
+         *
+         * @param pfx optional internally defined prefix for the message
+         * @param msg message to log
          */
-        typedef void (*logger_fn_type)(level, const char*);
+        typedef void (*logger_fn_type)(level l,
+                                       const char* pfx, const char* msg);
 
         static const char* to_c_string(enum level level)
         {
@@ -66,11 +71,12 @@ namespace wsrep
             case info:    return "info";
             case warning: return "warning";
             case error:   return "error";
+            case unknown: break;
             };
             return "unknown";
         }
 
-        log(enum wsrep::log::level level, const char* prefix = "")
+        log(enum wsrep::log::level level, const char* prefix = "L:")
             : level_(level)
             , prefix_(prefix)
             , oss_()
@@ -80,12 +86,12 @@ namespace wsrep
         {
             if (logger_fn_)
             {
-                logger_fn_(level_, oss_.str().c_str());
+                logger_fn_(level_, prefix_, oss_.str().c_str());
             }
             else
             {
                 wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-                os_ << prefix_ << ": " << oss_.str() << std::endl;
+                os_ << prefix_ << oss_.str() << std::endl;
             }
         }
 

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -564,22 +564,25 @@ namespace
 
     void logger_cb(wsrep_log_level_t level, const char* msg)
     {
+        static const char* const pfx("P:"); // "provider"
+        wsrep::log::level ll(wsrep::log::unknown);
         switch (level)
         {
         case WSREP_LOG_FATAL:
         case WSREP_LOG_ERROR:
-            wsrep::log_error() << msg;
+            ll = wsrep::log::error;
             break;
         case WSREP_LOG_WARN:
-            wsrep::log_warning() << msg;
+            ll = wsrep::log::warning;
             break;
         case WSREP_LOG_INFO:
-            wsrep::log_info() <<  msg;
+            ll = wsrep::log::info;
             break;
         case WSREP_LOG_DEBUG:
-            wsrep::log_debug() << msg;
+            ll = wsrep::log::debug;
             break;
         }
+        wsrep::log(ll, pfx) << msg;
     }
 
     static int init_thread_service(void* dlh,

--- a/test/wsrep-lib_test.cpp
+++ b/test/wsrep-lib_test.cpp
@@ -44,9 +44,10 @@ static std::string debug_log_level;
 
 
 static void log_fn(wsrep::log::level level,
+                   const char* pfx,
                    const char* msg)
 {
-    log_file << wsrep::log::to_c_string(level) << ": " << msg << std::endl;
+    log_file << wsrep::log::to_c_string(level) << " " << pfx << msg << std::endl;
 }
 
 static bool parse_arg(const std::string& arg)


### PR DESCRIPTION
Refs codership/wsrep-lib#148
Modify logger signature to allow prefixes