### PR TITLE
fix for: allowing application to set transaction as PA unsafe

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -359,7 +359,8 @@ static int apply_write_set(wsrep::server_state& server_state,
                              ws_meta,
                              data);
     }
-    else if (ws_meta.flags() == 0 || wsrep::prepares_transaction(ws_meta.flags()))
+    else if (ws_meta.flags() == 0 || ws_meta.flags() == wsrep::provider::flag::pa_unsafe ||
+             wsrep::prepares_transaction(ws_meta.flags()))
     {
         wsrep::high_priority_service* sa(
             server_state.find_streaming_applier(


### PR DESCRIPTION
The new feature which allows application to set transaction as PA unsafe
caused problems for streaming replication use cases. In apply_write_set(),
it is assumed that write set flags must be 0 for existing streaming
replication transaction. However, if SR transaction modifies non PK table,
the replicated fragment may have pa_unsafe flag.
Fixed by changing the condition detecting SR transactions to accept pa_unsafe
flag. This avoids the apply_write_set() execution from falling down to assert(0)
in the "condition tree"