### PR TITLE
Remove method transaction::clear_fragments()

### DIFF
--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -251,7 +251,6 @@ namespace wsrep
         int release_commit_order(wsrep::unique_lock<wsrep::mutex>&);
         void streaming_rollback(wsrep::unique_lock<wsrep::mutex>&);
         int replay(wsrep::unique_lock<wsrep::mutex>&);
-        void clear_fragments();
         void cleanup();
         void debug_log_state(const char*) const;
         void debug_log_key_append(const wsrep::key& key) const;

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -629,7 +629,7 @@ int wsrep::transaction::after_commit()
             client_state_.server_state_.stop_streaming_client(&client_state_);
             lock.lock();
         }
-        clear_fragments();
+        streaming_context_.cleanup();
     }
 
     switch (client_state_.mode())
@@ -767,7 +767,7 @@ int wsrep::transaction::after_rollback()
 
     if (is_streaming() && state() != s_must_replay)
     {
-        clear_fragments();
+        streaming_context_.cleanup();
     }
 
     if (state() == s_aborting)
@@ -1903,7 +1903,7 @@ int wsrep::transaction::replay(wsrep::unique_lock<wsrep::mutex>& lock)
         }
         if (is_streaming())
         {
-            clear_fragments();
+            streaming_context_.cleanup();
         }
         provider().release(ws_handle_);
         break;
@@ -1913,7 +1913,7 @@ int wsrep::transaction::replay(wsrep::unique_lock<wsrep::mutex>& lock)
         if (is_streaming())
         {
             client_service_.remove_fragments();
-            clear_fragments();
+            streaming_context_.cleanup();
         }
         state(lock, s_aborted);
         ret = 1;
@@ -1927,11 +1927,6 @@ int wsrep::transaction::replay(wsrep::unique_lock<wsrep::mutex>& lock)
                     wsrep::log::debug_level_transaction,
                     "replay returned" << replay_ret);
     return ret;
-}
-
-void wsrep::transaction::clear_fragments()
-{
-    streaming_context_.cleanup();
 }
 
 void wsrep::transaction::cleanup()


### PR DESCRIPTION
Remove the method as it does nothing, except for calling
`streaming_context_.clear()`. This led to a situation where we have
two ways to do the same thing, and it is annoying, if one wants to search
for all places where streaming_context is cleaned up.