### PR TITLE
Assertion transaction.is_streaming() in wsrep::transaction::adopt()

### DIFF
--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -276,6 +276,7 @@ namespace wsrep
         wsrep::sr_key_set sr_keys_;
         wsrep::mutable_buffer apply_error_buf_;
         wsrep::xid xid_;
+        bool streaming_rollback_in_progress_;
     };
 
     static inline const char* to_c_string(enum wsrep::transaction::state state)


### PR DESCRIPTION
Assertion is_streaming() fires in transaction::adopt() when a
transaction is BF aborted, while it is in s_executing state, and it
manages to complete rollback and cleanup while the BF aborter is
executing streaming_rollback() with client_state lock is unlocked.
In this case method transaction::adopt() finds a transaction that is
no longer marked as streaming, triggering the assertion.
A condition variable and flag streaming_rollback_in_progress_ now
prevents a client thread to finish rollback, even if the BF aborter
has temporarily unlocked the client_state lock.