### PR TITLE
Fixup to previous commit. Since dbsim implies that logger function is

### DIFF
--- a/dbsim/db_server.hpp
+++ b/dbsim/db_server.hpp
@@ -22,6 +22,7 @@
 
 #include "wsrep/gtid.hpp"
 #include "wsrep/client_state.hpp"
+#include "wsrep/reporter.hpp"
 
 #include "db_storage_engine.hpp"
 #include "db_server_state.hpp"
@@ -41,9 +42,7 @@ namespace db
     public:
         server(simulator& simulator,
                const std::string& name,
-               const std::string& address,
-               const std::string& status_file);
-        ~server();
+               const std::string& address);
         void applier_thread();
         void start_applier();
         void stop_applier();
@@ -70,6 +69,7 @@ namespace db
         wsrep::default_mutex mutex_;
         wsrep::default_condition_variable cond_;
         db::server_service server_service_;
+        wsrep::reporter reporter_;
         db::server_state server_state_;
         std::atomic<size_t> last_client_id_;
         std::atomic<size_t> last_transaction_id_;

--- a/dbsim/db_simulator.cpp
+++ b/dbsim/db_simulator.cpp
@@ -137,8 +137,7 @@ void db::simulator::start()
                         std::make_unique<db::server>(
                             *this,
                             name_os.str(),
-                            address_os.str(),
-                            name_os.str() + "_" + params_.status_file))));
+                            address_os.str()))));
         if (it.second == false)
         {
             throw wsrep::runtime_error("Failed to add server");


### PR DESCRIPTION
static and global, it cannot use the reporter object, which must be a
non-static member of server class.