### PR TITLE
Introduced macro to silence implicit-fallthrough warning

### DIFF
--- a/include/wsrep/compiler.hpp
+++ b/include/wsrep/compiler.hpp
@@ -34,8 +34,11 @@
  *                  left empty.
  * WSREP_UNUSED - Can be used to mark variables which may be present in
  *                debug builds but not in release builds.
+ * WSREP_FALLTHROUGH - Silence implicit fallthrough warning.
  */
 
+#ifndef WSREP_LIB_COMPILER_HPP
+#define WSREP_LIB_COMPILER_HPP
 
 #if __cplusplus >= 201103L && !(__GNUC__ == 4 && __GNUG_MINOR__ < 8)
 #define WSREP_NORETURN [[noreturn]]
@@ -51,3 +54,17 @@
 #define WSREP_OVERRIDE
 #endif // __cplusplus >= 201103L
 #define WSREP_UNUSED __attribute__((unused))
+
+#if __GNUC__ >= 7
+#define WSREP_FALLTHROUGH __attribute__((fallthrough))
+#elif defined(__clang__)
+#  if defined(__has_warning)
+#    if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
+#      define WSREP_FALLTHROUGH [[clang::fallthrough]]
+#    endif
+#  endif
+#else  // __clang __
+#define WSREP_FALLTHROUGH ((void)0)
+#endif // __GNUC__ >= 7 || (__clang__ && __clang_major__ >= 10)
+
+#endif // WSREP_LIB_COMPILER_HPP

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -1086,7 +1086,7 @@ void wsrep::server_state::on_sync()
             break;
         case s_connected:
             state(lock, s_joiner);
-            // fall through
+            WSREP_FALLTHROUGH;
         case s_joiner:
             state(lock, s_initializing);
             break;
@@ -1096,7 +1096,7 @@ void wsrep::server_state::on_sync()
             break;
         case s_initialized:
             state(lock, s_joined);
-            // fall through
+            WSREP_FALLTHROUGH;
         default:
             /* State */
             state(lock, s_synced);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -677,9 +677,9 @@ int wsrep::transaction::before_rollback()
         case s_preparing:
             // Error detected during prepare phase
             state(lock, s_must_abort);
-            // fall through
+            WSREP_FALLTHROUGH;
         case s_prepared:
-            // fall through
+            WSREP_FALLTHROUGH;
         case s_executing:
             // Voluntary rollback
             if (is_streaming())
@@ -850,7 +850,7 @@ int wsrep::transaction::after_statement()
             break;
         }
         // Continue to replay if rollback() changed the state to s_must_replay
-        // Fall through
+        WSREP_FALLTHROUGH;
     case s_must_replay:
     {
         if (is_xa() && !ordered())
@@ -1404,7 +1404,7 @@ int wsrep::transaction::streaming_step(wsrep::unique_lock<wsrep::mutex>& lock,
     switch (streaming_context_.fragment_unit())
     {
     case streaming_context::row:
-        // fall through
+        WSREP_FALLTHROUGH;
     case streaming_context::statement:
         streaming_context_.increment_unit_counter(1);
         break;


### PR DESCRIPTION
The fallthrough comment is not enough to silence the warning
with -Wimplicit-fallthrough=5.
