### PR TITLE
Introduce set_provider() method for server_state

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -299,6 +299,16 @@ namespace wsrep
                           const wsrep::provider::services& services
                           = wsrep::provider::services());
 
+        /**
+         * Set provider.
+         *
+         * @param Pointer to provider.
+         *
+         * @return Zero in case of success, non-zero in case of failure.
+         */
+        int set_provider(wsrep::provider* provider);
+
+        /** Unload/unset provider. */
         void unload_provider();
 
         bool is_provider_loaded() const { return provider_ != 0; }
@@ -310,12 +320,8 @@ namespace wsrep
          *
          * @throw wsrep::runtime_error if provider has not been loaded
          *
-         * @todo This should not be virtual. However, currently there
-         *       is no mechanism for tests and integrations to provide
-         *       their own provider implementations, so this is kept virtual
-         *       for time being.
          */
-        virtual wsrep::provider& provider() const
+        wsrep::provider& provider() const
         {
             if (provider_ == 0)
             {
@@ -622,6 +628,7 @@ namespace wsrep
             , streaming_appliers_()
             , streaming_appliers_recovered_()
             , provider_()
+            , owns_provider_()
             , name_(name)
             , id_(wsrep::id::undefined())
             , incoming_address_(incoming_address)
@@ -703,6 +710,7 @@ namespace wsrep
         streaming_appliers_map streaming_appliers_;
         bool streaming_appliers_recovered_;
         wsrep::provider* provider_;
+        bool owns_provider_; /** True if the provider was loaded by this. */
         std::string name_;
         wsrep::id id_;
         std::string incoming_address_;

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -501,13 +501,28 @@ int wsrep::server_state::load_provider(
                                                provider_spec,
                                                provider_options,
                                                services);
+    if (provider_)
+    {
+        owns_provider_ = true;
+    }
     return (provider_ ? 0 : 1);
+}
+
+int wsrep::server_state::set_provider(wsrep::provider* provider)
+{
+    if (provider_)
+    {
+        return 1;
+    }
+    provider_ = provider;
+    return 0;
 }
 
 void wsrep::server_state::unload_provider()
 {
     delete provider_;
     provider_ = 0;
+    owns_provider_ = false;
 }
 
 int wsrep::server_state::connect(const std::string& cluster_name,
@@ -542,7 +557,10 @@ int wsrep::server_state::disconnect()
 
 wsrep::server_state::~server_state()
 {
-    delete provider_;
+    if (owns_provider_)
+    {
+        delete provider_;
+    }
 }
 
 std::vector<wsrep::provider::status_variable>

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -246,11 +246,14 @@ namespace wsrep
             , mutex_()
             , cond_()
             , provider_(*this)
-        { }
+        {
+            set_provider(&provider_);
+        }
 
-        wsrep::mock_provider& provider() const WSREP_OVERRIDE
-        { return provider_; }
-
+        wsrep::mock_provider& mock_provider() const
+        {
+            return provider_;
+        }
         // mock connected state for tests without overriding the connect()
         // method.
         int mock_connect(const std::string& own_id,

--- a/test/nbo_test.cpp
+++ b/test/nbo_test.cpp
@@ -63,9 +63,9 @@ BOOST_FIXTURE_TEST_CASE(test_local_nbo,
 
     // There must have been two toi write sets, one with
     // start transaction flag, another with commit flag.
-    BOOST_REQUIRE(sc.provider().toi_write_sets() == 2);
-    BOOST_REQUIRE(sc.provider().toi_start_transaction() == 1);
-    BOOST_REQUIRE(sc.provider().toi_commit() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_write_sets() == 2);
+    BOOST_REQUIRE(sc.mock_provider().toi_start_transaction() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_commit() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_local_nbo_cert_failure,
@@ -79,7 +79,7 @@ BOOST_FIXTURE_TEST_CASE(test_local_nbo_cert_failure,
     key.append_key_part("k2", 2);
     wsrep::key_array keys{key};
     std::string data("data");
-    sc.provider().certify_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_certification_failed;
     BOOST_REQUIRE(cc.begin_nbo_phase_one(
                       keys,
                       wsrep::const_buffer(data.data(),
@@ -139,9 +139,9 @@ BOOST_FIXTURE_TEST_CASE(test_applying_nbo,
     BOOST_REQUIRE(nbo_cs->toi_mode() == wsrep::client_state::m_undefined);
 
     // There must have been one toi write set with commit flag.
-    BOOST_REQUIRE(sc.provider().toi_write_sets() == 1);
-    BOOST_REQUIRE(sc.provider().toi_start_transaction() == 0);
-    BOOST_REQUIRE(sc.provider().toi_commit() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_write_sets() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_start_transaction() == 0);
+    BOOST_REQUIRE(sc.mock_provider().toi_commit() == 1);
 }
 
 // This test case operates through server_state object in order to

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -240,7 +240,7 @@ BOOST_FIXTURE_TEST_CASE(server_state_applying_1pc_rollback,
                         applying_server_fixture)
 {
     /* make sure default success result is flipped to error_fatal */
-    ss.provider().commit_order_leave_result_ = wsrep::provider::success;
+    ss.mock_provider().commit_order_leave_result_ = wsrep::provider::success;
     hps.fail_next_applying_ = true;
     char buf[1] = { 1 };
     BOOST_REQUIRE(ss.on_apply(hps, ws_handle, ws_meta,
@@ -255,7 +255,7 @@ BOOST_FIXTURE_TEST_CASE(server_state_applying_2pc_rollback,
                         applying_server_fixture)
 {
     /* make sure default success result is flipped to error_fatal */
-    ss.provider().commit_order_leave_result_ = wsrep::provider::success;
+    ss.mock_provider().commit_order_leave_result_ = wsrep::provider::success;
     hps.do_2pc_ = true;
     hps.fail_next_applying_ = true;
     char buf[1] = { 1 };

--- a/test/toi_test.cpp
+++ b/test/toi_test.cpp
@@ -41,9 +41,9 @@ BOOST_FIXTURE_TEST_CASE(test_toi_mode,
     BOOST_REQUIRE(cc.leave_toi_local(err) == 0);
     BOOST_REQUIRE(cc.mode() == wsrep::client_state::m_local);
     BOOST_REQUIRE(cc.toi_mode() == wsrep::client_state::m_undefined);
-    BOOST_REQUIRE(sc.provider().toi_write_sets() == 1);
-    BOOST_REQUIRE(sc.provider().toi_start_transaction() == 1);
-    BOOST_REQUIRE(sc.provider().toi_commit() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_write_sets() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_start_transaction() == 1);
+    BOOST_REQUIRE(sc.mock_provider().toi_commit() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_toi_applying,

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -17,20 +17,19 @@
  * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "wsrep/transaction.hpp"
 #include "wsrep/provider.hpp"
+#include "wsrep/transaction.hpp"
 
-#include "test_utils.hpp"
 #include "client_state_fixture.hpp"
+#include "test_utils.hpp"
 
 #include <boost/mpl/vector.hpp>
 
 namespace
 {
-    typedef
-    boost::mpl::vector<replicating_client_fixture_sync_rm,
-                       replicating_client_fixture_async_rm>
-    replicating_fixtures;
+    typedef boost::mpl::vector<replicating_client_fixture_sync_rm,
+                               replicating_client_fixture_async_rm>
+        replicating_fixtures;
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_append_key_data,
@@ -39,7 +38,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_append_key_data,
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
     BOOST_REQUIRE(tc.is_empty());
-    int vals[3] = {1, 2, 3};
+    int vals[3] = { 1, 2, 3 };
     wsrep::key key(wsrep::key::exclusive);
     for (int i(0); i < 3; ++i)
     {
@@ -57,8 +56,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_append_key_data,
 //
 // Test a succesful 1PC transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc, T,
-                                 replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc, T, replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -98,12 +96,11 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc, T,
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
 
-
 //
 // Test a voluntary rollback
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_rollback, T,
-                                 replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_rollback, T, replicating_fixtures,
+                                 T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -133,9 +130,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_rollback, T,
 //
 // Test a 1PC transaction which gets BF aborted before before_commit
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_before_before_commit, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_bf_before_before_commit, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -167,8 +163,6 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(cc.current_error());
 }
-
-
 
 //
 // Test a 1PC transaction which gets BF aborted during before_commit via
@@ -249,9 +243,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(cc.current_error());
 }
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_during_commit_order_enter, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_bf_during_commit_order_enter,
+                                 T, replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -263,7 +256,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().commit_order_enter_result_ = wsrep::provider::error_bf_abort;
+    sc.mock_provider().commit_order_enter_result_
+        = wsrep::provider::error_bf_abort;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -272,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == true);
     BOOST_REQUIRE(tc.ordered() == true);
 
-    sc.provider().commit_order_enter_result_ = wsrep::provider::success;
+    sc.mock_provider().commit_order_enter_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -292,9 +286,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction for which prepare data fails
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_error_during_prepare_data, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_error_during_prepare_data, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -331,9 +324,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets killed by DBMS before certification
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_killed_before_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_killed_before_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -371,13 +363,12 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 // Test a transaction which gets BF aborted inside provider before
 // certification result is known. Replaying will be successful
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_bf_before_cert_result_replay_success,
-    replicating_client_fixture_sync_rm)
+BOOST_FIXTURE_TEST_CASE(transaction_bf_before_cert_result_replay_success,
+                        replicating_client_fixture_sync_rm)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
-    sc.provider().certify_result_ = wsrep::provider::error_bf_abort;
-    sc.provider().replay_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_bf_abort;
+    sc.mock_provider().replay_result_ = wsrep::provider::success;
 
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
@@ -392,18 +383,18 @@ BOOST_FIXTURE_TEST_CASE(
 // certification result is known. Replaying will fail because of
 // certification failure.
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_bf_before_cert_result_replay_cert_fail,
-    replicating_client_fixture_sync_rm)
+BOOST_FIXTURE_TEST_CASE(transaction_bf_before_cert_result_replay_cert_fail,
+                        replicating_client_fixture_sync_rm)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
-    sc.provider().certify_result_ = wsrep::provider::error_bf_abort;
-    sc.provider().replay_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_bf_abort;
+    sc.mock_provider().replay_result_
+        = wsrep::provider::error_certification_failed;
 
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.will_replay_called() == true);
-    BOOST_REQUIRE(cc.after_statement() );
+    BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
     BOOST_REQUIRE(tc.active() == false);
@@ -415,8 +406,8 @@ BOOST_FIXTURE_TEST_CASE(
 // result replaying of transaction.
 //
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_during_before_commit_certified, T,
-    replicating_fixtures, T)
+    transaction_1pc_bf_during_before_commit_certified, T, replicating_fixtures,
+    T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -459,8 +450,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 // should not generate seqno for write set meta.
 //
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_before_unordered_cert_failure, T,
-    replicating_fixtures, T)
+    transaction_1pc_bf_before_unordered_cert_failure, T, replicating_fixtures,
+    T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -472,7 +463,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
     cc.sync_point_enabled_ = "wsrep_before_certification";
     cc.sync_point_action_ = wsrep::mock_client_service::spa_bf_abort_unordered;
-    sc.provider().certify_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_certification_failed;
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_cert_failed);
     BOOST_REQUIRE(tc.certified() == false);
@@ -481,7 +473,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborting);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
-    BOOST_REQUIRE(cc.after_statement() );
+    BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(tc.active() == false);
     BOOST_REQUIRE(tc.ordered() == false);
     BOOST_REQUIRE(tc.certified() == false);
@@ -491,9 +483,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets "warning error" from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_warning_error_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_warning_error_from_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -505,7 +496,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_warning;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_warning;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -513,7 +504,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -533,8 +524,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 // Test a 1PC transaction which gets transaction missing from certify call
 //
 BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_transaction_missing_from_certify, T,
-    replicating_fixtures, T)
+    transaction_1pc_transaction_missing_from_certify, T, replicating_fixtures,
+    T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -546,7 +537,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_transaction_missing;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_transaction_missing;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -554,7 +546,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -573,9 +565,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets size exceeded error from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_size_exceeded_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_size_exceeded_from_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -587,7 +578,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_size_exceeded;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_size_exceeded;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -595,7 +586,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -614,9 +605,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets connection failed error from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_connection_failed_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_connection_failed_from_certify,
+                                 T, replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -628,7 +618,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_connection_failed;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_connection_failed;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -636,7 +627,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -655,9 +646,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets not allowed error from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_no_allowed_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_no_allowed_from_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -669,7 +659,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_not_allowed;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_not_allowed;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -677,7 +667,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -696,9 +686,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets fatal error from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_fatal_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_fatal_from_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -710,7 +699,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_fatal;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_fatal;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -718,7 +707,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -738,9 +727,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a 1PC transaction which gets unknown from certify call
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_unknown_from_certify, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_unknown_from_certify, T,
+                                 replicating_fixtures, T)
 {
     wsrep::mock_server_state& sc(T::sc);
     wsrep::mock_client& cc(T::cc);
@@ -752,7 +740,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    sc.provider().certify_result_ = wsrep::provider::error_unknown;
+    sc.mock_provider().certify_result_ = wsrep::provider::error_unknown;
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -760,7 +748,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(tc.ordered() == false);
 
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
 
     // Rollback sequence
     BOOST_REQUIRE(cc.before_rollback() == 0);
@@ -820,9 +808,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a transaction which gets BF aborted before before_statement.
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_before_before_statement, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_bf_before_before_statement, T,
+                                 replicating_fixtures, T)
 {
     wsrep::client_state& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -852,9 +839,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
 //
 // Test a transaction which gets BF aborted before after_statement.
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_before_after_statement, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_bf_before_after_statement, T,
+                                 replicating_fixtures, T)
 {
     wsrep::client_state& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -874,9 +860,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(cc.current_error());
 }
 
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(
-    transaction_1pc_bf_abort_after_after_statement, T,
-    replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_1pc_bf_abort_after_after_statement,
+                                 T, replicating_fixtures, T)
 {
     wsrep::client_state& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -899,9 +884,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
 }
 
-BOOST_FIXTURE_TEST_CASE(
-    transaction_1pc_autocommit_retry_bf_aborted,
-    replicating_client_fixture_autocommit)
+BOOST_FIXTURE_TEST_CASE(transaction_1pc_autocommit_retry_bf_aborted,
+                        replicating_client_fixture_autocommit)
 {
 
     cc.start_transaction(wsrep::transaction_id(1));
@@ -1175,8 +1159,8 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_ownership, T,
 // Test before_command() with keep_command_error param
 // BF abort right after before_command()
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_before_command, T,
-                                 replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_before_command,
+                                 T, replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -1209,8 +1193,9 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_before_command,
 // Test before_command() with keep_command_error param
 // BF abort right after after_command_before_result()
 //
-BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_after_command_before_result, T,
-                                 replicating_fixtures, T)
+BOOST_FIXTURE_TEST_CASE_TEMPLATE(
+    transaction_keep_error_bf_after_after_command_before_result, T,
+    replicating_fixtures, T)
 {
     wsrep::mock_client& cc(T::cc);
     const wsrep::transaction& tc(T::tc);
@@ -1241,11 +1226,9 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(transaction_keep_error_bf_after_after_command_b
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
 
-BOOST_FIXTURE_TEST_CASE(transaction_1pc_applying,
-                        applying_client_fixture)
+BOOST_FIXTURE_TEST_CASE(transaction_1pc_applying, applying_client_fixture)
 {
-    start_transaction(wsrep::transaction_id(1),
-                      wsrep::seqno(1));
+    start_transaction(wsrep::transaction_id(1), wsrep::seqno(1));
     BOOST_REQUIRE(cc.before_commit() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_committing);
     BOOST_REQUIRE(cc.ordered_commit() == 0);
@@ -1258,9 +1241,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_1pc_applying,
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
 
-
-BOOST_FIXTURE_TEST_CASE(transaction_applying_rollback,
-                        applying_client_fixture)
+BOOST_FIXTURE_TEST_CASE(transaction_applying_rollback, applying_client_fixture)
 {
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborting);
@@ -1289,9 +1270,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 //
@@ -1300,8 +1281,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_1pc_commit,
 BOOST_FIXTURE_TEST_CASE(transaction_row_batch_streaming_1pc_commit,
                         streaming_client_fixture_row)
 {
-    BOOST_REQUIRE(cc.enable_streaming(
-                      wsrep::streaming_context::row, 2) == 0);
+    BOOST_REQUIRE(cc.enable_streaming(wsrep::streaming_context::row, 2) == 0);
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 0);
@@ -1311,17 +1291,16 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_batch_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 //
 // Test 1PC row streaming with two separate statements
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_row_streaming_1pc_commit_two_statements,
-    streaming_client_fixture_row)
+BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_1pc_commit_two_statements,
+                        streaming_client_fixture_row)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
@@ -1334,9 +1313,9 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 3);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 3);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 //
@@ -1347,8 +1326,9 @@ BOOST_FIXTURE_TEST_CASE(
 // internally. This will cause the transaction to leave before_prepare()
 // in aborted state.
 //
-BOOST_FIXTURE_TEST_CASE(transaction_streaming_1pc_bf_abort_during_fragment_removal,
-                        streaming_client_fixture_row)
+BOOST_FIXTURE_TEST_CASE(
+    transaction_streaming_1pc_bf_abort_during_fragment_removal,
+    streaming_client_fixture_row)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
@@ -1374,13 +1354,12 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_rollback,
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().rollback_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().rollback_fragments() == 1);
 
     wsrep::high_priority_service* hps(
-        sc.find_streaming_applier(
-            sc.id(), wsrep::transaction_id(1)));
+        sc.find_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
@@ -1404,7 +1383,6 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_bf_abort_executing,
     BOOST_REQUIRE(cc.after_statement());
     wsrep_test::terminate_streaming_applier(sc, sc.id(),
                                             wsrep::transaction_id(1));
-
 }
 //
 // Test streaming certification failure during fragment replication
@@ -1415,19 +1393,19 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_non_commit,
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
-    sc.provider().certify_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_certification_failed;
     BOOST_REQUIRE(cc.after_row() == 1);
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(cc.after_statement() == 1);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().rollback_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().rollback_fragments() == 1);
 
     wsrep::high_priority_service* hps(
-        sc.find_streaming_applier(
-            sc.id(), wsrep::transaction_id(1)));
+        sc.find_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
@@ -1444,21 +1422,21 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_cert_fail_commit,
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
-    sc.provider().certify_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_certification_failed;
     BOOST_REQUIRE(cc.before_commit() == 1);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_cert_failed);
-    sc.provider().certify_result_ = wsrep::provider::success;
+    sc.mock_provider().certify_result_ = wsrep::provider::success;
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(cc.after_rollback() == 0);
-    BOOST_REQUIRE(cc.after_statement() );
+    BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().rollback_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().rollback_fragments() == 1);
 
     wsrep::high_priority_service* hps(
-        sc.find_streaming_applier(
-            sc.id(), wsrep::transaction_id(1)));
+        sc.find_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
@@ -1485,12 +1463,10 @@ BOOST_FIXTURE_TEST_CASE(transaction_row_streaming_bf_abort_committing,
     BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(cc.after_statement() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_committed);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
-
-
 
 BOOST_FIXTURE_TEST_CASE(transaction_byte_streaming_1pc_commit,
                         streaming_client_fixture_byte)
@@ -1503,17 +1479,15 @@ BOOST_FIXTURE_TEST_CASE(transaction_byte_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_byte_batch_streaming_1pc_commit,
                         streaming_client_fixture_byte)
 {
-    BOOST_REQUIRE(
-        cc.enable_streaming(
-            wsrep::streaming_context::bytes, 2) == 0);
+    BOOST_REQUIRE(cc.enable_streaming(wsrep::streaming_context::bytes, 2) == 0);
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 0);
@@ -1523,14 +1497,14 @@ BOOST_FIXTURE_TEST_CASE(transaction_byte_batch_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
-
-BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_statement_with_no_effect,
-                        streaming_client_fixture_statement)
+BOOST_FIXTURE_TEST_CASE(
+    transaction_statement_streaming_statement_with_no_effect,
+    streaming_client_fixture_statement)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 0);
@@ -1546,9 +1520,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_statement_with_no_effect
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_1pc_commit,
@@ -1564,17 +1538,16 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_statement_batch_streaming_1pc_commit,
                         streaming_client_fixture_statement)
 {
-    BOOST_REQUIRE(
-        cc.enable_streaming(
-            wsrep::streaming_context::statement, 2) == 0);
+    BOOST_REQUIRE(cc.enable_streaming(wsrep::streaming_context::statement, 2)
+                  == 0);
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 0);
@@ -1590,9 +1563,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_batch_streaming_1pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
@@ -1601,7 +1574,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 0);
-    sc.provider().certify_result_ = wsrep::provider::error_certification_failed;
+    sc.mock_provider().certify_result_
+        = wsrep::provider::error_certification_failed;
     BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(cc.current_error() == wsrep::e_deadlock_error);
     // Note: Due to possible limitation in wsrep-API error codes
@@ -1610,13 +1584,12 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
     // If the limitation is lifted later on or the provider is fixed,
     // the above check should be change for fragments == 0,
     // rollback_fragments == 0.
-    BOOST_REQUIRE(sc.provider().fragments() == 1);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 0);
-    BOOST_REQUIRE(sc.provider().rollback_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 0);
+    BOOST_REQUIRE(sc.mock_provider().rollback_fragments() == 1);
 
     wsrep::high_priority_service* hps(
-        sc.find_streaming_applier(
-            sc.id(), wsrep::transaction_id(1)));
+        sc.find_streaming_applier(sc.id(), wsrep::transaction_id(1)));
     BOOST_REQUIRE(hps);
     hps->rollback(wsrep::ws_handle(), wsrep::ws_meta());
     hps->after_apply();
@@ -1630,38 +1603,27 @@ BOOST_FIXTURE_TEST_CASE(transaction_statement_streaming_cert_fail,
 
 BOOST_AUTO_TEST_CASE(transaction_state_strings)
 {
-    BOOST_REQUIRE(wsrep::to_string(
-                      wsrep::transaction::s_executing) == "executing");
-    BOOST_REQUIRE(wsrep::to_string(
-                      wsrep::transaction::s_preparing) == "preparing");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_certifying) == "certifying");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_committing) == "committing");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_ordered_commit) == "ordered_commit");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_committed) == "committed");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_cert_failed) == "cert_failed");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_must_abort) == "must_abort");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_aborting) == "aborting");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_aborted) == "aborted");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_must_replay) == "must_replay");
-    BOOST_REQUIRE(
-        wsrep::to_string(
-            wsrep::transaction::s_replaying) == "replaying");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_executing)
+                  == "executing");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_preparing)
+                  == "preparing");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_certifying)
+                  == "certifying");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_committing)
+                  == "committing");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_ordered_commit)
+                  == "ordered_commit");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_committed)
+                  == "committed");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_cert_failed)
+                  == "cert_failed");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_must_abort)
+                  == "must_abort");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_aborting)
+                  == "aborting");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_aborted) == "aborted");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_must_replay)
+                  == "must_replay");
+    BOOST_REQUIRE(wsrep::to_string(wsrep::transaction::s_replaying)
+                  == "replaying");
 }

--- a/test/transaction_test_2pc.cpp
+++ b/test/transaction_test_2pc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2021 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -22,8 +22,7 @@
 //
 // Test a succesful 2PC transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_2pc,
-                        replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc, replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -52,9 +51,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_2pc,
 //
 // Test a 2PC transaction which gets BF aborted before before_prepare
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_before_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_before_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -69,7 +67,7 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborting);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
-    BOOST_REQUIRE(cc.after_statement() );
+    BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(tc.active() == false);
     BOOST_REQUIRE(tc.ordered() == false);
     BOOST_REQUIRE(tc.certified() == false);
@@ -79,9 +77,8 @@ BOOST_FIXTURE_TEST_CASE(
 //
 // Test a 2PC transaction which gets BF aborted before before_prepare
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_after_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_after_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -110,9 +107,8 @@ BOOST_FIXTURE_TEST_CASE(
 // Test a 2PC transaction which gets BF aborted after_prepare() and
 // the rollback takes place before entering before_commit().
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_after_after_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_after_after_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -139,9 +135,8 @@ BOOST_FIXTURE_TEST_CASE(
 // Test a 2PC transaction which gets BF aborted between after_prepare()
 // and before_commit()
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_before_commit,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_before_commit,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -168,14 +163,12 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
 
-
 //
 // Test a 2PC transaction which gets BF aborted when trying to grab
 // commit order.
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_during_commit_order_enter,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_during_commit_order_enter,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -183,13 +176,14 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
     BOOST_REQUIRE(cc.before_prepare() == 0);
     BOOST_REQUIRE(cc.after_prepare() == 0);
-    sc.provider().commit_order_enter_result_ = wsrep::provider::error_bf_abort;
+    sc.mock_provider().commit_order_enter_result_
+        = wsrep::provider::error_bf_abort;
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.will_replay_called() == true);
     BOOST_REQUIRE(tc.certified() == true);
     BOOST_REQUIRE(tc.ordered() == true);
-    sc.provider().commit_order_enter_result_ = wsrep::provider::success;
+    sc.mock_provider().commit_order_enter_result_ = wsrep::provider::success;
     BOOST_REQUIRE(cc.before_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.after_rollback() == 0);
@@ -205,7 +199,6 @@ BOOST_FIXTURE_TEST_CASE(
 //                       STREAMING REPLICATION                               //
 ///////////////////////////////////////////////////////////////////////////////
 
-
 BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit,
                         streaming_client_fixture_row)
 {
@@ -218,9 +211,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit_two_statements,
@@ -239,9 +232,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit_two_statements,
     BOOST_REQUIRE(cc.ordered_commit() == 0);
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(cc.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().fragments() == 3);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 3);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }
 
 //
@@ -251,8 +244,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit_two_statements,
 // internally. This will cause the transaction to leave before_prepare()
 // in aborted state.
 //
-BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_bf_abort_during_fragment_removal,
-                        streaming_client_fixture_row)
+BOOST_FIXTURE_TEST_CASE(
+    transaction_streaming_2pc_bf_abort_during_fragment_removal,
+    streaming_client_fixture_row)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
@@ -270,8 +264,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_bf_abort_during_fragment_remov
 //                              APPLYING                                     //
 ///////////////////////////////////////////////////////////////////////////////
 
-BOOST_FIXTURE_TEST_CASE(transaction_2pc_applying,
-                        applying_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_applying, applying_client_fixture_2pc)
 {
     BOOST_REQUIRE(cc.before_prepare() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_preparing);

--- a/test/transaction_test_xa.cpp
+++ b/test/transaction_test_xa.cpp
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2019-2021 Codership Oy <info@codership.com>
+ *
+ * This file is part of wsrep-lib.
+ *
+ * Wsrep-lib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Wsrep-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "client_state_fixture.hpp"
 #include <iostream>
 
 //
 // Test a successful XA transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa,
-                        replicating_client_fixture_sync_rm)
+BOOST_FIXTURE_TEST_CASE(transaction_xa, replicating_client_fixture_sync_rm)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 
@@ -25,8 +42,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa,
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_prepared);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
     // XA START + PREPARE fragment
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 1);
 
     BOOST_REQUIRE(cc.before_commit() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_committing);
@@ -37,8 +54,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa,
     BOOST_REQUIRE(cc.after_commit() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_committed);
     // XA PREPARE and XA COMMIT fragments
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 
     BOOST_REQUIRE(cc.after_statement() == 0);
     BOOST_REQUIRE(tc.active() == false);
@@ -46,7 +63,6 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa,
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
-
 
 //
 // Test detaching of XA transactions
@@ -60,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_commit_by_xid,
     cc1.assign_xid(xid);
     cc1.before_prepare();
     cc1.after_prepare();
-    BOOST_REQUIRE(sc.provider().fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 1);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
 
     cc1.xa_detach();
@@ -72,7 +88,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_commit_by_xid,
     cc2.assign_xid(xid);
     BOOST_REQUIRE(cc2.client_state::commit_by_xid(xid) == 0);
     BOOST_REQUIRE(cc2.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 
     // xa_detach() creates a streaming applier, clean it up
     wsrep::mock_high_priority_service* hps(
@@ -94,7 +110,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_rollback_by_xid,
     cc1.assign_xid(xid);
     cc1.before_prepare();
     cc1.after_prepare();
-    BOOST_REQUIRE(sc.provider().fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 1);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
 
     cc1.xa_detach();
@@ -106,7 +122,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_rollback_by_xid,
     cc2.assign_xid(xid);
     BOOST_REQUIRE(cc2.rollback_by_xid(xid) == 0);
     BOOST_REQUIRE(cc2.after_statement() == 0);
-    BOOST_REQUIRE(sc.provider().rollback_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().rollback_fragments() == 1);
 
     // xa_detach() creates a streaming applier, clean it up
     wsrep::mock_high_priority_service* hps(
@@ -118,7 +134,6 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_rollback_by_xid,
     sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
     server_service.release_high_priority_service(hps);
 }
-
 
 //
 // Test XA replay
@@ -214,8 +229,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_replay_after_command_after_result,
 //
 // Test a successful XA transaction lifecycle (applying side)
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
-                        applying_client_fixture)
+BOOST_FIXTURE_TEST_CASE(transaction_xa_applying, applying_client_fixture)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 
@@ -249,8 +263,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
 //
 // Test a successful XA transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
-                        streaming_client_fixture_byte)
+BOOST_FIXTURE_TEST_CASE(transaction_xa_sr, streaming_client_fixture_byte)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 
@@ -261,8 +274,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
     BOOST_REQUIRE(cc.after_row() == 0);
     BOOST_REQUIRE(tc.streaming_context().fragments_certified() == 1);
     // XA START fragment with data
-    BOOST_REQUIRE(sc.provider().fragments() == 1);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
 
     BOOST_REQUIRE(tc.active());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
@@ -274,7 +287,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
     BOOST_REQUIRE(cc.after_prepare() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_prepared);
     // XA PREPARE fragment
-    BOOST_REQUIRE(sc.provider().fragments() == 2);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 2);
 
     BOOST_REQUIRE(cc.before_commit() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_committing);
@@ -290,7 +303,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
     // XA START fragment (with data), XA PREPARE fragment and XA COMMIT fragment
-    BOOST_REQUIRE(sc.provider().fragments() == 3);
-    BOOST_REQUIRE(sc.provider().start_fragments() == 1);
-    BOOST_REQUIRE(sc.provider().commit_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().fragments() == 3);
+    BOOST_REQUIRE(sc.mock_provider().start_fragments() == 1);
+    BOOST_REQUIRE(sc.mock_provider().commit_fragments() == 1);
 }


### PR DESCRIPTION
This allows injecting an application allocated provider into
server_state.

After this virtual provider getter is unnecessary. Made the getter
normal method and fixed unit tests accordingly.
