### PR TITLE
Fix cleanup for non-prepared XA transactions

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -633,7 +633,7 @@ namespace wsrep
         void xa_detach()
         {
             assert(mode_ == m_local);
-            assert(state_ == s_none || state_ == s_exec);
+            assert(state_ == s_none || state_ == s_exec || state_ == s_quitting);
             transaction_.xa_detach();
         }
 


### PR DESCRIPTION
Cleanup XA transaction which is marked as prepared in DBMS, but not in
wsrep-lib side. This may happen if the DBMS runs with wsrep disabled.