### PR TITLE
Handle disconnecting state in on_sync()

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -1051,6 +1051,8 @@ void wsrep::server_state::on_sync()
     {
         switch (state_)
         {
+        case s_disconnecting:
+            break;
         case s_synced:
             break;
         case s_connected:                 // Seed node path: provider becomes
@@ -1077,7 +1079,7 @@ void wsrep::server_state::on_sync()
         // Calls to on_sync() in synced state are possible if
         // server desyncs itself from the group. Provider does not
         // inform about this through callbacks.
-        if (state_ != s_synced)
+        if (state_ != s_synced && state_ != s_disconnecting)
         {
             state(lock, s_synced);
         }

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -935,3 +935,14 @@ BOOST_FIXTURE_TEST_CASE(server_state_xa_not_orphaned,
     BOOST_REQUIRE(not ss.find_streaming_applier(
                       meta_commit_s3.server_id(), meta_commit_s3.transaction_id()));
 }
+
+BOOST_FIXTURE_TEST_CASE(server_state_sync_in_disconnecting,
+                        sst_first_server_fixture)
+{
+    bootstrap();
+    ss.disconnect();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_disconnecting);
+    // Synced event from the provider must not change the state.
+    ss.on_sync();
+    BOOST_REQUIRE(ss.state() == wsrep::server_state::s_disconnecting);
+}


### PR DESCRIPTION
When disconnecting from the group, the sync event from the
provider must not change the state back to synced.
