### PR TITLE
Check for a valid provider instead of connection state in

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -832,7 +832,7 @@ int
 wsrep::server_state::set_encryption_key(std::vector<unsigned char>& key)
 {
     encryption_key_ = key;
-    if (state_ != s_disconnected)
+    if (provider_)
     {
         wsrep::const_buffer const key(encryption_key_.data(),
                                       encryption_key_.size());


### PR DESCRIPTION
`server_state::set_encryption_key()`

Refs codership/wsrep-lib#192