### PR TITLE
MDEV-29512 deadlock between commit monitor and THD::LOCK_thd_data mutex

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -791,13 +791,14 @@ int wsrep::transaction::release_commit_order(
 {
     lock.unlock();
     int ret(provider().commit_order_enter(ws_handle_, ws_meta_));
-    lock.lock();
     if (!ret)
     {
         server_service_.set_position(client_service_, ws_meta_.gtid());
         ret = provider().commit_order_leave(ws_handle_, ws_meta_,
                                             apply_error_buf_);
     }
+    // grabbing lock here, as set_position may call for sync wait in galera side
+    lock.lock();
     return ret;
 }
 


### PR DESCRIPTION
Grabbing back the lock later, after set_position has been called. This is because set_position may have to wait for correct seqno position and calls sync wait in galera side. Such wait would happen while holding the lock, which would case hanging like reported in MDEV-29512

PR for MDEV-29512 contains a mtr test for reproducing one such deadlock scenario.