### PR TITLE
Return error codes instead of throwing exception

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -369,12 +369,11 @@ namespace wsrep
 
         /**
          * Wait until server reaches given state.
+         *
+         * @return Zero in case of success, non-zero if the
+         * wait was interrupted.
          */
-        void wait_until_state(enum state state) const
-        {
-            wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-            wait_until_state(lock, state);
-        }
+        int wait_until_state(enum state state) const;
 
         /**
          * Return GTID at the position when server connected to
@@ -509,8 +508,10 @@ namespace wsrep
          *
          * @param client_service
          * @param error code of the SST operation
+         *
+         * @return Zero in case of success, non-zero on error.
          */
-        void sst_received(wsrep::client_service& cs, int error);
+        int sst_received(wsrep::client_service& cs, int error);
 
         /**
          * This method must be called after the server initialization
@@ -644,7 +645,8 @@ namespace wsrep
         int desync(wsrep::unique_lock<wsrep::mutex>&);
         void resync(wsrep::unique_lock<wsrep::mutex>&);
         void state(wsrep::unique_lock<wsrep::mutex>&, enum state);
-        void wait_until_state(wsrep::unique_lock<wsrep::mutex>&, enum state) const;
+        void wait_until_state(wsrep::unique_lock<wsrep::mutex>&,
+                              enum state) const;
         // Interrupt all threads which are waiting for state
         void interrupt_state_waiters(wsrep::unique_lock<wsrep::mutex>&);
 

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -343,7 +343,7 @@ BOOST_FIXTURE_TEST_CASE(server_state_sst_first_join_with_sst,
     // case where SST contains the view in which SST happens.
     server_service.logged_view(second_view);
     server_service.position(wsrep::gtid(cluster_id, wsrep::seqno(2)));
-    ss.sst_received(cc, 0);
+    BOOST_REQUIRE(ss.sst_received(cc, 0) == 0);
     clear_sync_point_action();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joined);
     ss.on_sync();
@@ -429,7 +429,7 @@ BOOST_FIXTURE_TEST_CASE(
     ss.prepare_for_sst();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joiner);
     server_service.position(wsrep::gtid::undefined());
-    ss.sst_received(cc, 1);
+    BOOST_REQUIRE(ss.sst_received(cc, 1) == 0);
     disconnect();
 }
 
@@ -442,8 +442,7 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joiner);
     initialization_failure_action();
     server_service.position(wsrep::gtid(second_view.state_id()));
-    BOOST_REQUIRE_EXCEPTION(ss.sst_received(cc, 0),
-                            wsrep::runtime_error, exception_check);
+    BOOST_REQUIRE(ss.sst_received(cc, 0) != 0);
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_initializing);
     BOOST_REQUIRE_EXCEPTION(ss.on_view(second_view, &hps),
                             wsrep::runtime_error, exception_check);
@@ -466,7 +465,7 @@ BOOST_FIXTURE_TEST_CASE(
     // case where SST contains the view in which SST happens.
     server_service.logged_view(second_view);
     server_service.position(wsrep::gtid(cluster_id, wsrep::seqno(2)));
-    ss.sst_received(cc, 0);
+    BOOST_REQUIRE(ss.sst_received(cc, 0) == 0);
     clear_sync_point_action();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joined);
     disconnect();
@@ -507,7 +506,7 @@ BOOST_FIXTURE_TEST_CASE(server_state_init_first_join_with_sst,
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joiner);
     server_service.logged_view(second_view);
     server_service.position(wsrep::gtid(cluster_id, wsrep::seqno(2)));
-    ss.sst_received(cc, 0);
+    BOOST_REQUIRE(ss.sst_received(cc, 0) == 0);
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_joined);
     ss.on_sync();
     BOOST_REQUIRE(ss.state() == wsrep::server_state::s_synced);


### PR DESCRIPTION
Changed server_state public methods sst_received() and wait_until_state()
to report errors as return value instead of throwing exceptions.
This was done to gradually get rid of public methods which report
errors via exceptions.

This change was part of MDEV-30419.