### PR TITLE
Removing assert() calls from public headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,14 @@ jobs:
             CC: gcc
             version: "11"
             type: Release
+          - os: ubuntu-22.04
+            CC: gcc
+            version: "12"
+            type: Debug
+          - os: ubuntu-22.04
+            CC: gcc
+            version: "12"
+            type: Release
           # Clang
           - os: ubuntu-18.04
             CC: clang

--- a/dbsim/db_client_service.cpp
+++ b/dbsim/db_client_service.cpp
@@ -21,6 +21,8 @@
 #include "db_high_priority_service.hpp"
 #include "db_client.hpp"
 
+#include <cassert>
+
 db::client_service::client_service(db::client& client)
     : wsrep::client_service()
     , client_(client)

--- a/dbsim/db_storage_engine.cpp
+++ b/dbsim/db_storage_engine.cpp
@@ -20,6 +20,8 @@
 #include "db_storage_engine.hpp"
 #include "db_client.hpp"
 
+#include <cassert>
+
 void db::storage_engine::transaction::start(db::client* cc)
 {
     wsrep::unique_lock<wsrep::mutex> lock(se_.mutex_);

--- a/dbsim/db_storage_engine.cpp
+++ b/dbsim/db_storage_engine.cpp
@@ -108,7 +108,6 @@ wsrep::view db::storage_engine::get_view() const
 
 void db::storage_engine::validate_position(const wsrep::gtid& gtid) const
 {
-    using std::rel_ops::operator<=;
     if (position_.id() == gtid.id() && gtid.seqno() <= position_.seqno())
     {
         std::ostringstream os;

--- a/dbsim/db_threads.cpp
+++ b/dbsim/db_threads.cpp
@@ -22,10 +22,12 @@
 #include "wsrep/logger.hpp"
 
 #include <cassert>
+#include <cstdint>
 #include <pthread.h>
 
 #include <algorithm>
 #include <atomic>
+#include <array>
 #include <chrono>
 #include <map>
 #include <mutex>

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -27,7 +27,6 @@
 #include "transaction_id.hpp"
 #include "compiler.hpp"
 
-#include <cassert>
 #include <cstring>
 
 #include <string>

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -554,11 +554,7 @@ namespace wsrep
         }
 
         enum state state(wsrep::unique_lock<wsrep::mutex>&
-                         lock WSREP_UNUSED) const
-        {
-            assert(lock.owns_lock());
-            return state_;
-        }
+                         lock WSREP_UNUSED) const;
 
         /**
          * Get provider status variables.

--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -553,8 +553,7 @@ namespace wsrep
             return state(lock);
         }
 
-        enum state state(wsrep::unique_lock<wsrep::mutex>&
-                         lock WSREP_UNUSED) const;
+        enum state state(wsrep::unique_lock<wsrep::mutex>& lock) const;
 
         /**
          * Get provider status variables.

--- a/include/wsrep/streaming_context.hpp
+++ b/include/wsrep/streaming_context.hpp
@@ -165,7 +165,7 @@ namespace wsrep
         void cleanup();
     private:
 
-        void check_fragment_seqno(wsrep::seqno seqno WSREP_UNUSED);
+        void check_fragment_seqno(wsrep::seqno seqno);
 
         size_t fragments_certified_;
         std::vector<wsrep::seqno> fragments_;

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -29,7 +29,6 @@
 #include "buffer.hpp"
 #include "xid.hpp"
 
-#include <cassert>
 #include <vector>
 
 namespace wsrep

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,26 +3,29 @@
 #
 
 add_library(wsrep-lib
+  allowlist_service_v1.cpp
   client_state.cpp
+  config_service_v1.cpp
+  event_service_v1.cpp
   exception.cpp
   gtid.cpp
   id.cpp
-  xid.cpp
   key.cpp
   logger.cpp
   provider.cpp
   provider_options.cpp
+  reporter.cpp
   seqno.cpp
-  view.cpp
   server_state.cpp
+  sr_key_set.cpp
+  streaming_context.cpp
   thread.cpp
   thread_service_v1.cpp
   tls_service_v1.cpp
-  event_service_v1.cpp
   transaction.cpp
   uuid.cpp
-  reporter.cpp
-  allowlist_service_v1.cpp
+  view.cpp
   wsrep_provider_v26.cpp
-  config_service_v1.cpp)
+  xid.cpp
+  )
 target_link_libraries(wsrep-lib wsrep_api_v26 pthread ${WSREP_LIB_LIBDL})

--- a/src/config_service_v1.cpp
+++ b/src/config_service_v1.cpp
@@ -23,6 +23,8 @@
 #include "wsrep/logger.hpp"
 #include "wsrep/provider_options.hpp"
 
+#include <cassert>
+
 namespace wsrep_config_service_v1
 {
     wsrep_config_service_v1_t service{ 0 };

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -23,6 +23,7 @@
 #include "wsrep_provider_v26.hpp"
 
 #include <dlfcn.h>
+#include <cassert>
 #include <memory>
 
 wsrep::provider* wsrep::provider::make_provider(

--- a/src/reporter.cpp
+++ b/src/reporter.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <iomanip>
 
+#include <cassert>
 #include <cstring>  // strerror()
 #include <cstdlib>  // mkstemp()
 #include <cerrno>   // errno

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -1132,6 +1132,13 @@ int wsrep::server_state::on_apply(
     }
 }
 
+enum wsrep::server_state::state wsrep::server_state::state(
+    wsrep::unique_lock<wsrep::mutex>& lock WSREP_UNUSED) const
+{
+    assert(lock.owns_lock());
+    return state_;
+}
+
 void wsrep::server_state::start_streaming_client(
     wsrep::client_state* client_state)
 {

--- a/src/sr_key_set.cpp
+++ b/src/sr_key_set.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Codership Oy <info@codership.com>
+ * Copyright (C) 2023 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -17,31 +17,27 @@
  * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WSREP_SR_KEY_SET_HPP
-#define WSREP_SR_KEY_SET_HPP
+#include "wsrep/sr_key_set.hpp"
 
-#include <set>
-#include <map>
-#include <string>
+#include "wsrep/key.hpp"
 
-namespace wsrep
+#include <cassert>
+
+void wsrep::sr_key_set::insert(const wsrep::key& key)
 {
-    class key;
-    class sr_key_set
+    assert(key.size() >= 2);
+    if (key.size() < 2)
     {
-    public:
-        typedef std::set<std::string> leaf_type;
-        typedef std::map<std::string, leaf_type > branch_type;
-        sr_key_set()
-            : root_()
-        { }
-        void insert(const wsrep::key& key);
-        const branch_type& root() const { return root_; }
-        void clear();
-        bool empty() const { return root_.empty(); }
-    private:
-        branch_type root_;
-    };
+        throw wsrep::runtime_error("Invalid key size");
+    }
+
+    root_[std::string(static_cast<const char*>(key.key_parts()[0].data()),
+                      key.key_parts()[0].size())]
+        .insert(std::string(static_cast<const char*>(key.key_parts()[1].data()),
+                            key.key_parts()[1].size()));
 }
 
-#endif // WSREP_KEY_SET_HPP
+void wsrep::sr_key_set::clear()
+{
+    root_.clear();
+}

--- a/src/streaming_context.cpp
+++ b/src/streaming_context.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 Codership Oy <info@codership.com>
+ *
+ * This file is part of wsrep-lib.
+ *
+ * Wsrep-lib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Wsrep-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "wsrep/streaming_context.hpp"
+
+#include <cassert>
+
+void wsrep::streaming_context::params(enum fragment_unit fragment_unit,
+                                      size_t fragment_size)
+{
+    if (fragment_size)
+    {
+        WSREP_LOG_DEBUG(
+            wsrep::log::debug_log_level(), wsrep::log::debug_level_streaming,
+            "Enabling streaming: " << fragment_unit << " " << fragment_size);
+    }
+    else
+    {
+        WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
+                        wsrep::log::debug_level_streaming,
+                        "Disabling streaming");
+    }
+    fragment_unit_ = fragment_unit;
+    fragment_size_ = fragment_size;
+    reset_unit_counter();
+}
+
+void wsrep::streaming_context::enable(enum fragment_unit fragment_unit,
+                                      size_t fragment_size)
+{
+    WSREP_LOG_DEBUG(
+        wsrep::log::debug_log_level(), wsrep::log::debug_level_streaming,
+        "Enabling streaming: " << fragment_unit << " " << fragment_size);
+    assert(fragment_size > 0);
+    fragment_unit_ = fragment_unit;
+    fragment_size_ = fragment_size;
+}
+
+void wsrep::streaming_context::disable()
+{
+    WSREP_LOG_DEBUG(wsrep::log::debug_log_level(),
+                    wsrep::log::debug_level_streaming, "Disabling streaming");
+    fragment_size_ = 0;
+}
+
+void wsrep::streaming_context::stored(wsrep::seqno seqno)
+{
+    check_fragment_seqno(seqno);
+    fragments_.push_back(seqno);
+}
+
+void wsrep::streaming_context::applied(wsrep::seqno seqno)
+{
+    check_fragment_seqno(seqno);
+    ++fragments_certified_;
+    fragments_.push_back(seqno);
+}
+
+void wsrep::streaming_context::rolled_back(wsrep::transaction_id id)
+{
+    assert(rollback_replicated_for_ == wsrep::transaction_id::undefined());
+    rollback_replicated_for_ = id;
+}
+
+void wsrep::streaming_context::cleanup()
+{
+    fragments_certified_ = 0;
+    fragments_.clear();
+    rollback_replicated_for_ = wsrep::transaction_id::undefined();
+    unit_counter_ = 0;
+    log_position_ = 0;
+}
+
+void wsrep::streaming_context::check_fragment_seqno(
+    wsrep::seqno seqno WSREP_UNUSED)
+{
+    assert(seqno.is_undefined() == false);
+    assert(fragments_.empty() || fragments_.back() < seqno);
+}

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -28,6 +28,7 @@
 #include "wsrep/server_service.hpp"
 #include "wsrep/client_service.hpp"
 
+#include <cassert>
 #include <sstream>
 #include <memory>
 

--- a/test/client_state_fixture.hpp
+++ b/test/client_state_fixture.hpp
@@ -31,7 +31,7 @@ namespace
     struct replicating_client_fixture_sync_rm
     {
         replicating_client_fixture_sync_rm()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc, wsrep::client_id(1),
                  wsrep::client_state::m_local)
@@ -54,7 +54,7 @@ namespace
     struct replicating_two_clients_fixture_sync_rm
     {
         replicating_two_clients_fixture_sync_rm()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc1(sc, wsrep::client_id(1),
                   wsrep::client_state::m_local)
@@ -83,7 +83,7 @@ namespace
     struct replicating_client_fixture_async_rm
     {
         replicating_client_fixture_async_rm()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_async, server_service)
             , cc(sc, wsrep::client_id(1),
                  wsrep::client_state::m_local)
@@ -106,7 +106,7 @@ namespace
     struct replicating_client_fixture_2pc
     {
         replicating_client_fixture_2pc()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc,  wsrep::client_id(1),
                  wsrep::client_state::m_local)
@@ -130,7 +130,7 @@ namespace
     struct replicating_client_fixture_autocommit
     {
         replicating_client_fixture_autocommit()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc, wsrep::client_id(1),
                  wsrep::client_state::m_local)
@@ -154,7 +154,7 @@ namespace
     struct applying_client_fixture
     {
         applying_client_fixture()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1",
                  wsrep::server_state::rm_async, server_service)
             , cc(sc,
@@ -193,7 +193,7 @@ namespace
     struct applying_client_fixture_2pc
     {
         applying_client_fixture_2pc()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1",
                  wsrep::server_state::rm_async, server_service)
             , cc(sc,
@@ -228,7 +228,7 @@ namespace
     struct streaming_client_fixture_row
     {
         streaming_client_fixture_row()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc,
                  wsrep::client_id(1),
@@ -254,7 +254,7 @@ namespace
     struct streaming_client_fixture_byte
     {
         streaming_client_fixture_byte()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc,
                  wsrep::client_id(1),
@@ -279,7 +279,7 @@ namespace
     struct streaming_client_fixture_statement
     {
         streaming_client_fixture_statement()
-            : server_service(sc)
+            : server_service(&sc)
             , sc("s1", wsrep::server_state::rm_sync, server_service)
             , cc(sc,
                  wsrep::client_id(1),

--- a/test/mock_client_state.cpp
+++ b/test/mock_client_state.cpp
@@ -24,11 +24,11 @@
 int wsrep::mock_client_service::bf_rollback()
 {
     int ret(0);
-    if (client_state_.before_rollback())
+    if (client_state_->before_rollback())
     {
         ret = 1;
     }
-    else if (client_state_.after_rollback())
+    else if (client_state_->after_rollback())
     {
         ret = 1;
     }
@@ -38,11 +38,11 @@ int wsrep::mock_client_service::bf_rollback()
 enum wsrep::provider::status
 wsrep::mock_client_service::replay()
 {
-    wsrep::mock_high_priority_service hps(client_state_.server_state(),
-                                          &client_state_, true);
+    wsrep::mock_high_priority_service hps(client_state_->server_state(),
+                                          client_state_, true);
     enum wsrep::provider::status ret(
-        client_state_.provider().replay(
-            client_state_.transaction().ws_handle(),
+        client_state_->provider().replay(
+            client_state_->transaction().ws_handle(),
             &hps));
     ++replays_;
     return ret;

--- a/test/mock_storage_service.cpp
+++ b/test/mock_storage_service.cpp
@@ -25,7 +25,7 @@
 wsrep::mock_storage_service::mock_storage_service(
     wsrep::server_state& server_state,
     wsrep::client_id client_id)
-    : client_service_(client_state_)
+    : client_service_(&client_state_)
     , client_state_(server_state, client_service_, client_id,
                     wsrep::client_state::m_high_priority)
 {

--- a/test/server_context_test.cpp
+++ b/test/server_context_test.cpp
@@ -26,7 +26,7 @@ namespace
     struct server_fixture_base
     {
         server_fixture_base()
-            : server_service(ss)
+            : server_service(&ss)
             , ss("s1",
                  wsrep::server_state::rm_sync, server_service)
             , cc(ss,


### PR DESCRIPTION
Removed calls to assert() from public headers to have
full control when assertions are enabled in wsrep-lib
code regardless of parent project build configuration.
Moved methods containing assertions and non-trivial
code from headers into compilation units.
