### PR TITLE
Fix assertion unallowed state transition: connected -> joined

### DIFF
--- a/include/wsrep/server_state.hpp
+++ b/include/wsrep/server_state.hpp
@@ -674,6 +674,9 @@ namespace wsrep
         enum wsrep::provider::status send_pending_rollback_events(
           wsrep::unique_lock<wsrep::mutex>& lock);
 
+        // Handle returning from donor state.
+        void return_from_donor_state(wsrep::unique_lock<wsrep::mutex>& lock);
+
         wsrep::mutex& mutex_;
         wsrep::condition_variable& cond_;
         wsrep::server_service& server_service_;

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -173,15 +173,14 @@ namespace wsrep
         { return sst_before_init_; }
         std::string sst_request() WSREP_OVERRIDE { return ""; }
 
-        std::function<int()> start_sst_action{};
+        // Action to take when start_sst() method is called.
+        // This can be overriden by test case to inject custom
+        // behavior.
+        std::function<int()> start_sst_action{[](){ return 0; }};
         int start_sst(const std::string&, const wsrep::gtid&,
                       bool) WSREP_OVERRIDE
         {
-            if (start_sst_action)
-            {
-                return start_sst_action();
-            }
-            return 0;
+            return start_sst_action();
         }
 
         void

--- a/test/mock_server_state.hpp
+++ b/test/mock_server_state.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2013 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -172,11 +172,20 @@ namespace wsrep
         bool sst_before_init() const WSREP_OVERRIDE
         { return sst_before_init_; }
         std::string sst_request() WSREP_OVERRIDE { return ""; }
-        int start_sst(const std::string&,
-                      const wsrep::gtid&,
-                      bool) WSREP_OVERRIDE { return 0; }
-        void background_rollback(wsrep::client_state& client_state)
-            WSREP_OVERRIDE
+
+        std::function<int()> start_sst_action{};
+        int start_sst(const std::string&, const wsrep::gtid&,
+                      bool) WSREP_OVERRIDE
+        {
+            if (start_sst_action)
+            {
+                return start_sst_action();
+            }
+            return 0;
+        }
+
+        void
+        background_rollback(wsrep::client_state& client_state) WSREP_OVERRIDE
         {
             client_state.before_rollback();
             client_state.after_rollback();


### PR DESCRIPTION
When the donor lost its donor state during SST due to cluster partitioning, the state was erranously changed to `s_joined` in `sst_sent()`, which caused assertion failures in state checking.

Fixed by changing state to `s_joined` only if donor is still in `s_donor` state.