### PR TITLE
Postpone streaming_context cleanup into after_rollback()

### DIFF
--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -249,6 +249,8 @@ namespace wsrep
         int certify_commit(wsrep::unique_lock<wsrep::mutex>&);
         int append_sr_keys_for_commit();
         int release_commit_order(wsrep::unique_lock<wsrep::mutex>&);
+        void remove_fragments_in_storage_service_scope(
+            wsrep::unique_lock<wsrep::mutex>&);
         void streaming_rollback(wsrep::unique_lock<wsrep::mutex>&);
         int replay(wsrep::unique_lock<wsrep::mutex>&);
         void xa_replay_common(wsrep::unique_lock<wsrep::mutex>&);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -34,6 +34,11 @@ void wsrep_test::bf_abort_ordered(wsrep::client_state& cc)
     assert(cc.transaction().ordered());
     cc.bf_abort(wsrep::seqno(0));
 }
+
+void wsrep_test::bf_abort_in_total_order(wsrep::client_state& cc)
+{
+    cc.total_order_bf_abort(wsrep::seqno(0));
+}
 // BF abort method to abort transactions via provider
 void wsrep_test::bf_abort_provider(wsrep::mock_server_state& sc,
                                    const wsrep::transaction& tc,

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -44,6 +44,9 @@ namespace wsrep_test
                            const wsrep::transaction& tc,
                            wsrep::seqno bf_seqno);
 
+    // BF abort in total order
+    void bf_abort_in_total_order(wsrep::client_state&);
+
     // Terminate streaming applier by applying rollback fragment.
     void terminate_streaming_applier(
         wsrep::mock_server_state& sc,


### PR DESCRIPTION
Streaming_context was cleaned up in streaming_rollback(),
which could cause clearing fragment seqno vector while
it was still accessed by the hosting thread, causing
undefined behavior. Fixed by postponing streaming_context
cleanup for BF aborted SR transactions to always happen in
after_rollback().

Also found out that the streaming rollback for TOI
BF abort used regular BF abort codepath, which was not
correct because the streaming rollback must complete
before TOI operation executes. Fixed this by adjusting
bf_aborted_in_total_order_ before streaming_rollback()
gets called.

Updated wsrep-API/v26 to work with ASAN builds.
