### PR TITLE
Allow external locking for BF aborts

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -540,6 +540,13 @@ namespace wsrep
          * Brute force abort a transaction. This method should be
          * called by a transaction which needs to BF abort a conflicting
          * locally processing transaction.
+         *
+         * @param lock Lock to protect client state.
+         * @param bf_seqno Seqno of the BF aborter.
+         */
+        int bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno);
+        /**
+         * Wrapper to bf_abort() call, grabs lock internally.
          */
         int bf_abort(wsrep::seqno bf_seqno);
 
@@ -547,6 +554,11 @@ namespace wsrep
          * Brute force abort a transaction in total order. This method
          * should be called by the TOI operation which needs to
          * BF abort a transaction.
+         */
+        int total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno);
+
+        /**
+         * Wrapper to total_order_bf_abort(), grabs lock internally.
          */
         int total_order_bf_abort(wsrep::seqno bf_seqno);
 

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -535,8 +535,9 @@ int wsrep::client_state::bf_abort(wsrep::unique_lock<wsrep::mutex>& lock,
 {
     assert(lock.owns_lock());
     assert(mode_ == m_local || transaction_.is_streaming());
-    return transaction_.bf_abort(lock, bf_seqno);
-
+    auto ret = transaction_.bf_abort(lock, bf_seqno);
+    assert(lock.owns_lock());
+    return ret;
 }
 
 int wsrep::client_state::bf_abort(wsrep::seqno bf_seqno)
@@ -545,11 +546,14 @@ int wsrep::client_state::bf_abort(wsrep::seqno bf_seqno)
     return bf_abort(lock, bf_seqno);
 }
 
-int wsrep::client_state::total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno)
+int wsrep::client_state::total_order_bf_abort(
+    wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno)
 {
     assert(lock.owns_lock());
     assert(mode_ == m_local || transaction_.is_streaming());
-    return transaction_.total_order_bf_abort(lock, bf_seqno);
+    auto ret = transaction_.total_order_bf_abort(lock, bf_seqno);
+    assert(lock.owns_lock());
+    return ret;
 }
 
 int wsrep::client_state::total_order_bf_abort(wsrep::seqno bf_seqno)

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -530,18 +530,32 @@ void wsrep::client_state::xa_replay()
 //                                 BF                                       //
 //////////////////////////////////////////////////////////////////////////////
 
+int wsrep::client_state::bf_abort(wsrep::unique_lock<wsrep::mutex>& lock,
+                                  wsrep::seqno bf_seqno)
+{
+    assert(lock.owns_lock());
+    assert(mode_ == m_local || transaction_.is_streaming());
+    return transaction_.bf_abort(lock, bf_seqno);
+
+}
+
 int wsrep::client_state::bf_abort(wsrep::seqno bf_seqno)
 {
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
+    return bf_abort(lock, bf_seqno);
+}
+
+int wsrep::client_state::total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno)
+{
+    assert(lock.owns_lock());
     assert(mode_ == m_local || transaction_.is_streaming());
-    return transaction_.bf_abort(lock, bf_seqno);
+    return transaction_.total_order_bf_abort(lock, bf_seqno);
 }
 
 int wsrep::client_state::total_order_bf_abort(wsrep::seqno bf_seqno)
 {
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
-    assert(mode_ == m_local || transaction_.is_streaming());
-    return transaction_.total_order_bf_abort(lock, bf_seqno);
+    return total_order_bf_abort(lock, bf_seqno);
 }
 
 void wsrep::client_state::adopt_transaction(

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1075,6 +1075,7 @@ bool wsrep::transaction::bf_abort(
 
             lock.unlock();
             server_service_.background_rollback(client_state_);
+            lock.lock();
         }
     }
     return ret;


### PR DESCRIPTION
Added methods bf_abort() and total_order_bf_abort() which take
wsrep::unique_lock<wsrep::mutex> as argument to allow caller
to grab the mutex before attempting BF abort. The old calls
were kept for backwards compatibility and wrap the new calls
with internal locking.
