### PR TITLE
Make is_rollbacker_active() public, don't unlock for background rollback

### DIFF
--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -902,6 +902,15 @@ namespace wsrep
         {
             return current_error_status_;
         }
+
+        /**
+         * Return true if rollbacker is active. The caller should
+         * hold the mutex protecting client_state.
+         */
+        bool is_rollbacker_active()
+        {
+            return rollbacker_active_;
+        }
     protected:
         /**
          * Client context constuctor. This is protected so that it
@@ -1006,11 +1015,6 @@ namespace wsrep
         void set_rollbacker_active(bool value)
         {
             rollbacker_active_ = value;
-        }
-
-        bool is_rollbacker_active()
-        {
-            return rollbacker_active_;
         }
     };
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1073,9 +1073,7 @@ bool wsrep::transaction::bf_abort(
                 }
             }
 
-            lock.unlock();
             server_service_.background_rollback(client_state_);
-            lock.lock();
         }
     }
     return ret;


### PR DESCRIPTION
Make client_state::is_rollbacker_active() public

This is to allow BF aborted to check if the background
rollbacker thread was launched.

Also don't unlock the lock for launching the background
rollbacker to avoid race conditions in accessing the
victim state.
