### PR TITLE
Remove duplicate logic from after_statement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,9 @@ jobs:
       with:
         submodules: "recursive"
 
+    - name: Update packages
+      run: sudo apt update
+
     - name: Install compiler
       run: |
         sudo apt-get install -y ${{ matrix.config.CC }}-${{ matrix.config.version }}

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -192,6 +192,7 @@ namespace wsrep
         int before_statement();
 
         int after_statement();
+        int after_statement(wsrep::unique_lock<wsrep::mutex>&);
 
         void after_command_must_abort(wsrep::unique_lock<wsrep::mutex>&);
 

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -816,9 +816,15 @@ void wsrep::transaction::remove_fragments_in_storage_service_scope(
 
 int wsrep::transaction::after_statement()
 {
+  wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex());
+  return after_statement(lock);
+}
+
+int wsrep::transaction::after_statement(wsrep::unique_lock<wsrep::mutex>& lock)
+{
     int ret(0);
-    wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex());
     debug_log_state("after_statement_enter");
+    assert(lock.owns_lock());
     assert(client_state_.mode() == wsrep::client_state::m_local);
     assert(state() == s_executing ||
            state() == s_prepared ||


### PR DESCRIPTION
Remove bf abort handling `client_state::after_statement()`, since the same logic already appears later in `transaction::after_statement()`. Also, introduce `transaction::after_statement()` overload which takes a lock.