### PR TITLE
Failed to insert streaming client warning after replay

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -2071,7 +2071,9 @@ int wsrep::transaction::replay(wsrep::unique_lock<wsrep::mutex>& lock)
             wsrep::e_deadlock_error);
         if (is_streaming())
         {
+            lock.unlock();
             client_service_.remove_fragments();
+            lock.lock();
             streaming_context_.cleanup();
         }
         state(lock, s_aborted);


### PR DESCRIPTION
Avoid streaming context cleanup in after_rollback() hook, if transaction is going to replay. Otherwise, streaming client is not stopped and is left in streaming client map, potentially causing "Failed to insert streaming client" warning if the transaction goes for retry.