### PR TITLE
Phase out the use of WSREP_KEY_SHARED key type in favour of WSREP_KEY_REFERENCE

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1960,7 +1960,7 @@ int wsrep::transaction::append_sr_keys_for_commit()
                  j(i->second.begin());
              ret == 0 && j != i->second.end(); ++j)
         {
-            wsrep::key key(wsrep::key::shared);
+            wsrep::key key(wsrep::key::reference);
             key.append_key_part(i->first.data(), i->first.size());
             key.append_key_part(j->data(), j->size());
             ret = provider().append_key(ws_handle_, key);


### PR DESCRIPTION
(but keep support for it for backward compatibility) The only place where wsrep-lib made use of WSREP_KEY_SHARED is wsrep::append_sr_keys_for_commit() which is used only with protocols >= 4 so we don't need to worry about the protocol version and just change wsrep::key::shared to wsrep::key::reference.

Refs codership/wsrep-lib#227