### PR TITLE
Improve "Unallowed state transition" warning

### DIFF
--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -1038,8 +1038,9 @@ void wsrep::client_state::state(
         };
     if (!allowed[state_][state])
     {
-        wsrep::log_warning() << "client_state: Unallowed state transition: "
-                             << state_ << " -> " << state;
+        wsrep::log_warning()
+            << "client_state: Unallowed state transition: "
+            << wsrep::to_string(state_) << " -> " << wsrep::to_string(state);
         assert(0);
     }
     state_hist_.push_back(state_);


### PR DESCRIPTION
In client_state, change warning "Unallowed state transition" to print state names instead of numbers.