### PR TITLE
Add application defined sequential consistency for certification

### DIFF
--- a/dbsim/db_client.hpp
+++ b/dbsim/db_client.hpp
@@ -62,7 +62,6 @@ namespace db
         void start();
         wsrep::client_state& client_state() { return client_state_; }
         wsrep::client_service& client_service() { return client_service_; }
-        bool do_2pc() const { return false; }
     private:
         friend class db::server_state;
         friend class db::client_service;

--- a/dbsim/db_high_priority_service.hpp
+++ b/dbsim/db_high_priority_service.hpp
@@ -69,6 +69,7 @@ namespace db
         high_priority_service& operator=(const high_priority_service&);
         db::server& server_;
         db::client& client_;
+        uint64_t commit_seqno_;
     };
 
     class replayer_service : public db::high_priority_service

--- a/dbsim/db_params.cpp
+++ b/dbsim/db_params.cpp
@@ -95,6 +95,12 @@ db::params db::parse_args(int argc, char** argv)
          "Configure TLS service stubs.\n0 default disabled\n1 enabled\n"
          "2 enabled with short read/write and renegotiation simulation\n"
          "3 enabled with error simulation.")
+        ("check-sequential-consistency",
+         po::value<bool>(&params.check_sequential_consistency),
+         "Check if the provider provides sequential consistency")
+        ("do-2pc",
+         po::value<bool>(&params.do_2pc),
+         "Run commits in 2pc")
         ;
     try
     {

--- a/dbsim/db_params.hpp
+++ b/dbsim/db_params.hpp
@@ -27,42 +27,27 @@ namespace db
 {
     struct params
     {
-        size_t n_servers;
-        size_t n_clients;
-        size_t n_transactions;
-        size_t n_rows;
-        size_t max_data_size; // Maximum size of write set data payload.
-        bool random_data_size; // If true, randomize data payload size.
-        size_t alg_freq;
-        bool sync_wait;
-        std::string topology;
-        std::string wsrep_provider;
-        std::string wsrep_provider_options;
-        std::string status_file;
-        int debug_log_level;
-        int fast_exit;
-        int thread_instrumentation;
-        bool cond_checks;
-        int tls_service;
-        params()
-            : n_servers(0)
-            , n_clients(0)
-            , n_transactions(0)
-            , n_rows(1000)
-            , max_data_size(8)
-            , random_data_size(false)
-            , alg_freq(0)
-            , sync_wait(false)
-            , topology()
-            , wsrep_provider()
-            , wsrep_provider_options()
-            , status_file("status.json")
-            , debug_log_level(0)
-            , fast_exit(0)
-            , thread_instrumentation()
-            , cond_checks()
-            , tls_service()
-        { }
+        size_t n_servers{0};
+        size_t n_clients{0};
+        size_t n_transactions{0};
+        size_t n_rows{1000};
+        size_t max_data_size{8}; // Maximum size of write set data payload.
+        bool random_data_size{false}; // If true, randomize data payload size.
+        /* Asymmetric lock granularity frequency. */
+        size_t alg_freq{0};
+        /* Whether to sync wait before start of transaction. */
+        bool sync_wait{false};
+        std::string topology{};
+        std::string wsrep_provider{};
+        std::string wsrep_provider_options{};
+        std::string status_file{"status.json"};
+        int debug_log_level{0};
+        int fast_exit{0};
+        int thread_instrumentation{0};
+        bool cond_checks{false};
+        int tls_service{0};
+        bool check_sequential_consistency{false};
+        bool do_2pc{false};
     };
 
     params parse_args(int argc, char** argv);

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -413,11 +413,49 @@ namespace wsrep
 
         /** @name Commit ordering interface */
         /** @{ */
-        int before_prepare();
+
+        /**
+         * This method should be called before the transaction
+         * is prepared. This call certifies the transaction and
+         * assigns write set meta data.
+         *
+         * @param seq_cb Callback which is passed to underlying
+         *               certify() call. See wsrep::provider::certify().
+         *
+         * @return Zero on success, non-zero on failure.
+         */
+        int before_prepare(const wsrep::provider::seq_cb_t* seq_cb);
+
+        /** Same as before_prepare() above, but nullptr is passed
+         * to seq_cb. */
+        int before_prepare()
+        {
+            return before_prepare(nullptr);
+        }
 
         int after_prepare();
 
-        int before_commit();
+        /**
+         * This method should be called before transaction is committed.
+         * This call makes the transaction to enter commit time
+         * critical section. The critical section is left by calling
+         * ordered_commit().
+         *
+         * If before_prepare() is not called before this call, the
+         * before_prepare() is called internally.
+         *
+         * @param seq_cb Callback which is passed to underlying
+         *               before_prepare() call.
+         *
+         * @return Zero on success, non-zero on failure.
+         */
+        int before_commit(const wsrep::provider::seq_cb_t* seq_cb);
+
+        /** Same as before_commit(), but nullptr is passed to seq_cb. */
+        int before_commit()
+        {
+            return before_commit(nullptr);
+        }
 
         int ordered_commit();
 

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -332,10 +332,37 @@ namespace wsrep
         virtual int append_key(wsrep::ws_handle&, const wsrep::key&) = 0;
         virtual enum status append_data(
             wsrep::ws_handle&, const wsrep::const_buffer&) = 0;
+
+        /**
+         * Callback for application defined sequential consistency.
+         * The provider will call
+         * the callback once it can guarantee sequential consistency. */
+        typedef struct seq_cb {
+            /** Opaque caller context */
+            void *ctx;
+            /** Function to be called by the provider when sequential
+             * consistency is guaranteed. */
+            void (*fn)(void *ctx);
+        } seq_cb_t;
+
+        /**
+         * Certify the write set. 
+         *
+         * @param client_id[in] Id of the client session.
+         * @param ws_handle[in,out] Write set handle associated to the current
+         *                 transaction.
+         * @param flags[in] Flags associated to the write set (see struct flag).
+         * @param ws_meta[out] Write set meta data associated to the
+         *                     replicated write set.
+         * @param seq_cb[in] Optional callback for application defined
+         *                   sequential consistency.
+         *
+         * @return Status code defined in struct status.
+         */
         virtual enum status
-        certify(wsrep::client_id, wsrep::ws_handle&,
-                int,
-                wsrep::ws_meta&) = 0;
+        certify(wsrep::client_id client_id, wsrep::ws_handle& ws_handle,
+                int flags, wsrep::ws_meta& ws_meta, const seq_cb_t* seq_cb)
+            = 0;
         /**
          * BF abort a transaction inside provider.
          *

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -175,11 +175,12 @@ namespace wsrep
 
         int after_row();
 
-        int before_prepare(wsrep::unique_lock<wsrep::mutex>&);
+        int before_prepare(wsrep::unique_lock<wsrep::mutex>&,
+                           const wsrep::provider::seq_cb_t*);
 
         int after_prepare(wsrep::unique_lock<wsrep::mutex>&);
 
-        int before_commit();
+        int before_commit(const wsrep::provider::seq_cb_t*);
 
         int ordered_commit();
 
@@ -248,7 +249,8 @@ namespace wsrep
         bool abort_or_interrupt(wsrep::unique_lock<wsrep::mutex>&);
         int streaming_step(wsrep::unique_lock<wsrep::mutex>&, bool force = false);
         int certify_fragment(wsrep::unique_lock<wsrep::mutex>&);
-        int certify_commit(wsrep::unique_lock<wsrep::mutex>&);
+        int certify_commit(wsrep::unique_lock<wsrep::mutex>&,
+                           const wsrep::provider::seq_cb_t*);
         int append_sr_keys_for_commit();
         int release_commit_order(wsrep::unique_lock<wsrep::mutex>&);
         void remove_fragments_in_storage_service_scope(

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -365,12 +365,12 @@ int wsrep::client_state::next_fragment(const wsrep::ws_meta& meta)
     return transaction_.next_fragment(meta);
 }
 
-int wsrep::client_state::before_prepare()
+int wsrep::client_state::before_prepare(const wsrep::provider::seq_cb_t* seq_cb)
 {
     wsrep::unique_lock<wsrep::mutex> lock(mutex_);
     assert(owning_thread_id_ == wsrep::this_thread::get_id());
     assert(state_ == s_exec);
-    return transaction_.before_prepare(lock);
+    return transaction_.before_prepare(lock, seq_cb);
 }
 
 int wsrep::client_state::after_prepare()
@@ -381,11 +381,11 @@ int wsrep::client_state::after_prepare()
     return transaction_.after_prepare(lock);
 }
 
-int wsrep::client_state::before_commit()
+int wsrep::client_state::before_commit(const wsrep::provider::seq_cb_t* seq_cb)
 {
     assert(owning_thread_id_ == wsrep::this_thread::get_id());
     assert(state_ == s_exec || mode_ == m_local);
-    return transaction_.before_commit();
+    return transaction_.before_commit(seq_cb);
 }
 
 int wsrep::client_state::ordered_commit()

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -59,7 +59,7 @@ namespace wsrep
         enum wsrep::provider::status
         certify(wsrep::client_id, wsrep::ws_handle&,
                 int,
-                wsrep::ws_meta&) WSREP_OVERRIDE;
+                wsrep::ws_meta&, const seq_cb_t*) WSREP_OVERRIDE;
         enum wsrep::provider::status
         bf_abort(wsrep::seqno,
                  wsrep::transaction_id,

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -79,7 +79,8 @@ namespace wsrep
         certify(wsrep::client_id client_id,
                 wsrep::ws_handle& ws_handle,
                 int flags,
-                wsrep::ws_meta& ws_meta)
+                wsrep::ws_meta& ws_meta,
+                const seq_cb* /* Ignored in unit tests. */)
             WSREP_OVERRIDE
         {
             ws_handle = wsrep::ws_handle(ws_handle.transaction_id(), (void*)1);


### PR DESCRIPTION
Client state methods before_prepare() and before_commit() accept
a callback which is called by the provider after it can guarantee
sequential consistency. This allows application threads which wish to
maintain sequential consistency to enter before_prepare() and
before_commit() calls concurrently without waiting the prior call
 to finish.