### PR TITLE
Change github actions/cache to version 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
         message("::set-output name=timestamp::${current_date}")
 
     - name: Configure ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.ccache
         key: ${{ matrix.config.os }}-${{ matrix.config.CC }}-${{ matrix.config.version }}-${{ matrix.config.type }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
Cache service version 2 is going to get closed down,
replace with version 4.
