### PR TITLE
Add support for custom provider implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ wsrep-API/libwsrep_api_v26.a
 
 # Gcov generated files
 *.dgcov
+
+# Test logs
+wsrep-lib_test.log

--- a/include/wsrep/client_state.hpp
+++ b/include/wsrep/client_state.hpp
@@ -582,7 +582,8 @@ namespace wsrep
          * @param lock Lock to protect client state.
          * @param bf_seqno Seqno of the BF aborter.
          */
-        int bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno);
+        int bf_abort(wsrep::unique_lock<wsrep::mutex>& lock,
+                     wsrep::seqno bf_seqno);
         /**
          * Wrapper to bf_abort() call, grabs lock internally.
          */
@@ -593,7 +594,8 @@ namespace wsrep
          * should be called by the TOI operation which needs to
          * BF abort a transaction.
          */
-        int total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>& lock, wsrep::seqno bf_seqno);
+        int total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>& lock,
+                                 wsrep::seqno bf_seqno);
 
         /**
          * Wrapper to total_order_bf_abort(), grabs lock internally.

--- a/include/wsrep/id.hpp
+++ b/include/wsrep/id.hpp
@@ -93,6 +93,11 @@ namespace wsrep
         {
             return undefined_;
         }
+
+        /**
+         * Return id in string representation.
+         */
+        std::string to_string() const;
     private:
         static const wsrep::id undefined_;
         native_type data_;

--- a/include/wsrep/provider.hpp
+++ b/include/wsrep/provider.hpp
@@ -29,6 +29,7 @@
 
 #include <cstring>
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <ostream>
@@ -47,7 +48,7 @@ namespace wsrep
     class tls_service;
     class allowlist_service;
     class event_service;
-
+    class client_service;
     class stid
     {
     public:
@@ -283,7 +284,6 @@ namespace wsrep
             static const int streaming = (1 << 15);
             static const int snapshot = (1 << 16);
             static const int nbo = (1 << 17);
-
             /** decipher capability bitmask */
             static std::string str(int);
         };
@@ -375,6 +375,7 @@ namespace wsrep
          */
         virtual enum status bf_abort(wsrep::seqno bf_seqno,
                                      wsrep::transaction_id victim_trx,
+                                     wsrep::client_service& victim_ctx,
                                      wsrep::seqno& victim_seqno) = 0;
         virtual enum status rollback(wsrep::transaction_id) = 0;
         virtual enum status commit_order_enter(const wsrep::ws_handle&,
@@ -407,6 +408,7 @@ namespace wsrep
          * Leave total order isolation critical section
          */
         virtual enum status leave_toi(wsrep::client_id,
+                                      const wsrep::ws_meta& ws_meta,
                                       const wsrep::mutable_buffer& err) = 0;
 
         /**
@@ -509,11 +511,12 @@ namespace wsrep
          * @param provider_options Initial options to provider
          * @param thread_service Optional thread service implementation.
          */
-        static provider* make_provider(wsrep::server_state&,
-                                       const std::string& provider_spec,
-                                       const std::string& provider_options,
-                                       const wsrep::provider::services& services
-                                       = wsrep::provider::services());
+        static std::unique_ptr<provider> make_provider(
+            wsrep::server_state&,
+            const std::string& provider_spec,
+            const std::string& provider_options,
+            const wsrep::provider::services& services
+            = wsrep::provider::services());
 
     protected:
         wsrep::server_state& server_state_;

--- a/include/wsrep/seqno.hpp
+++ b/include/wsrep/seqno.hpp
@@ -51,6 +51,11 @@ namespace wsrep
             return (seqno_ == -1);
         }
 
+        wsrep::seqno prev() const
+        {
+            return seqno{seqno_ - 1};
+        }
+
         bool operator<(seqno other) const
         {
             return (seqno_ < other.seqno_);

--- a/include/wsrep/storage_service.hpp
+++ b/include/wsrep/storage_service.hpp
@@ -92,6 +92,17 @@ namespace wsrep
 
         virtual void store_globals() = 0;
         virtual void reset_globals() = 0;
+
+        /**
+         * Return true if the implementation requires storing
+         * and restoring global state. Return true by default
+         * since this is the original behavior. Stateless
+         * implementations may override.
+         */
+        virtual bool requires_globals() const {
+            return true;
+        }
+
     };
 }
 

--- a/include/wsrep/transaction.hpp
+++ b/include/wsrep/transaction.hpp
@@ -200,9 +200,11 @@ namespace wsrep
         void after_applying();
 
         bool bf_abort(wsrep::unique_lock<wsrep::mutex>& lock,
-                      wsrep::seqno bf_seqno);
+                      wsrep::seqno bf_seqno,
+                      wsrep::client_service&);
         bool total_order_bf_abort(wsrep::unique_lock<wsrep::mutex>&,
-                                  wsrep::seqno bf_seqno);
+                                  wsrep::seqno bf_seqno,
+                                  wsrep::client_service&);
 
         void clone_for_replay(const wsrep::transaction& other);
 

--- a/include/wsrep/view.hpp
+++ b/include/wsrep/view.hpp
@@ -117,9 +117,9 @@ namespace wsrep
         /**
          * Return true if the view is final
          */
-        bool final() const
+        bool is_final() const
         {
-            return (members_.empty() && own_index_ == -1);
+            return (status_ != status::primary && members_.empty() && own_index_ == -1);
         }
 
         /**

--- a/src/config_service_v1.cpp
+++ b/src/config_service_v1.cpp
@@ -151,6 +151,11 @@ int wsrep::config_service_v1_fetch(wsrep::provider& provider,
                                    wsrep::provider_options* options)
 {
     struct wsrep_st* wsrep = (struct wsrep_st*)provider.native();
+    if (wsrep == nullptr)
+    {
+        // Not a provider which was loaded via wsrep-API
+        return 0;
+    }
     if (config_service_v1_probe(wsrep->dlh))
     {
         wsrep::log_warning() << "Provider does not support config service v1";

--- a/src/id.cpp
+++ b/src/id.cpp
@@ -50,13 +50,23 @@ wsrep::id::id(const std::string& str)
     }
 }
 
+std::string wsrep::id::to_string() const
+{
+  std::ostringstream os;
+  os << *this;
+  return os.str();
+}
+
 std::ostream& wsrep::operator<<(std::ostream& os, const wsrep::id& id)
 {
     const char* ptr(static_cast<const char*>(id.data()));
     size_t size(id.size());
-    if (static_cast<size_t>(std::count_if(ptr, ptr + size, ::isalnum)) == size)
+    if (static_cast<size_t>(
+            std::count_if(ptr, ptr + size,
+                          [](char c) { return (::isalnum(c) || c == '\0'); }))
+        == size)
     {
-        return (os << std::string(ptr, size));
+        return (os << std::string(ptr, ::strnlen(ptr, size)));
     }
     else
     {

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -26,7 +26,7 @@
 #include <cassert>
 #include <memory>
 
-wsrep::provider* wsrep::provider::make_provider(
+std::unique_ptr<wsrep::provider> wsrep::provider::make_provider(
     wsrep::server_state& server_state,
     const std::string& provider_spec,
     const std::string& provider_options,
@@ -34,8 +34,8 @@ wsrep::provider* wsrep::provider::make_provider(
 {
     try
     {
-        return new wsrep::wsrep_provider_v26(
-            server_state, provider_options, provider_spec, services);
+        return std::unique_ptr<wsrep::provider>(new wsrep::wsrep_provider_v26(
+            server_state, provider_options, provider_spec, services));
     }
     catch (const wsrep::runtime_error& e)
     {
@@ -120,7 +120,6 @@ std::string wsrep::provider::capability::str(int caps)
     WSREP_PRINT_CAPABILITY(streaming,            "STREAMING");
     WSREP_PRINT_CAPABILITY(snapshot,             "READ_VIEW");
     WSREP_PRINT_CAPABILITY(nbo,                  "NBO");
-
 #undef WSREP_PRINT_CAPABILITY
 
     if (caps)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -57,7 +57,7 @@ void wsrep::view::print(std::ostream& os) const
        << "  status: " << to_c_string(status()) << "\n"
        << "  protocol_version: " << protocol_version() << "\n"
        << "  capabilities: " << provider::capability::str(capabilities())<<"\n"
-       << "  final: " << (final() ? "yes" : "no") << "\n"
+       << "  final: " << (is_final() ? "yes" : "no") << "\n"
        << "  own_index: " << own_index() << "\n"
        << "  members(" << members().size() << "):\n";
 

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -950,6 +950,7 @@ enum wsrep::provider::status
 wsrep::wsrep_provider_v26::bf_abort(
     wsrep::seqno bf_seqno,
     wsrep::transaction_id victim_id,
+    wsrep::client_service& /* Ignored here */,
     wsrep::seqno& victim_seqno)
 {
     wsrep_seqno_t wsrep_victim_seqno;
@@ -1047,6 +1048,7 @@ wsrep::wsrep_provider_v26::enter_toi(
 
 enum wsrep::provider::status
 wsrep::wsrep_provider_v26::leave_toi(wsrep::client_id client_id,
+                                     const wsrep::ws_meta&,
                                      const wsrep::mutable_buffer& err)
 {
     const wsrep_buf_t err_buf = { err.data(), err.size() };

--- a/src/wsrep_provider_v26.hpp
+++ b/src/wsrep_provider_v26.hpp
@@ -63,6 +63,7 @@ namespace wsrep
         enum wsrep::provider::status
         bf_abort(wsrep::seqno,
                  wsrep::transaction_id,
+                 wsrep::client_service&,
                  wsrep::seqno&) WSREP_OVERRIDE;
         enum wsrep::provider::status
         rollback(const wsrep::transaction_id) WSREP_OVERRIDE;
@@ -83,6 +84,7 @@ namespace wsrep
                                                int)
             WSREP_OVERRIDE;
         enum wsrep::provider::status leave_toi(wsrep::client_id,
+                                               const wsrep::ws_meta& ws_meta,
                                                const wsrep::mutable_buffer&)
             WSREP_OVERRIDE;
         std::pair<wsrep::gtid, enum wsrep::provider::status>

--- a/test/id_test.cpp
+++ b/test/id_test.cpp
@@ -38,6 +38,15 @@ BOOST_AUTO_TEST_CASE(id_test_uuid)
 
 BOOST_AUTO_TEST_CASE(id_test_string)
 {
+    std::string id_str("node1");
+    wsrep::id id(id_str);
+    std::ostringstream os;
+    os << id;
+    BOOST_REQUIRE(id_str == os.str());
+}
+
+BOOST_AUTO_TEST_CASE(id_test_string_max)
+{
     std::string id_str("1234567890123456");
     wsrep::id id(id_str);
     std::ostringstream os;

--- a/test/id_test.cpp
+++ b/test/id_test.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(id_test_uuid)
     wsrep::id id(uuid_str);
     std::ostringstream os;
     os << id;
-    BOOST_REQUIRE(uuid_str == os.str());
+    BOOST_REQUIRE_EQUAL(uuid_str, os.str());
 }
 
 BOOST_AUTO_TEST_CASE(id_test_string)
@@ -42,16 +42,19 @@ BOOST_AUTO_TEST_CASE(id_test_string)
     wsrep::id id(id_str);
     std::ostringstream os;
     os << id;
-    BOOST_REQUIRE(id_str == os.str());
+    BOOST_REQUIRE_EQUAL(id_str, os.str());
 }
 
 BOOST_AUTO_TEST_CASE(id_test_string_max)
 {
-    std::string id_str("1234567890123456");
+    std::string id_str("1234"
+                       "5678"
+                       "9012"
+                       "3456");
     wsrep::id id(id_str);
     std::ostringstream os;
     os << id;
-    BOOST_REQUIRE(id_str == os.str());
+    BOOST_REQUIRE_EQUAL(os.str(), "31323334-3536-3738-3930-313233343536");
 }
 
 BOOST_AUTO_TEST_CASE(id_test_string_too_long)
@@ -67,7 +70,7 @@ BOOST_AUTO_TEST_CASE(id_test_binary)
     wsrep::id id(data, sizeof(data));
     std::ostringstream os;
     os << id;
-    BOOST_REQUIRE(os.str() == "01020304-0506-0708-0900-010203040506");
+    BOOST_REQUIRE_EQUAL(os.str(), "01020304-0506-0708-0900-010203040506");
 }
 
 BOOST_AUTO_TEST_CASE(id_test_binary_too_long)
@@ -75,4 +78,38 @@ BOOST_AUTO_TEST_CASE(id_test_binary_too_long)
     char data[17] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4 ,5 ,6, 7};
     BOOST_REQUIRE_EXCEPTION(wsrep::id id(data, sizeof(data)),
                             wsrep::runtime_error, exception_check);;
+}
+
+BOOST_AUTO_TEST_CASE(id_test_binary_all_alphanumeric)
+{
+    char data[16] = {'a', 'a', 'a', 'a',
+                     'a', 'a', 'a', 'a',
+                     'a', 'a', 'a', 'a',
+                     'a', 'a', 'a', 'a'};
+    wsrep::id id(data, sizeof(data));
+    std::ostringstream os;
+    os << id;
+    /* Value of 'a' is 97 in ASCII, which is 0x61 in hex. */
+    BOOST_REQUIRE_EQUAL(os.str(), "61616161-6161-6161-6161-616161616161");
+}
+
+BOOST_AUTO_TEST_CASE(id_test_binary_all_except_middle_alphanumeric)
+{
+    char data[16] = {'a', 'a', 'a', 'a',
+                     'a', 'a', 'a', 'a',
+                     'a', 'a', '\0', 'a',
+                     'a', 'a', 'a', 'a'};
+    wsrep::id id(data, sizeof(data));
+    std::ostringstream os;
+    os << id;
+    BOOST_REQUIRE_EQUAL(os.str(), "61616161-6161-6161-6161-006161616161");
+}
+
+BOOST_AUTO_TEST_CASE(id_test_null)
+{
+    char data[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    wsrep::id id(data, sizeof(data));
+    std::ostringstream os;
+    os << id;
+    BOOST_REQUIRE_EQUAL(os.str(), "00000000-0000-0000-0000-000000000000");
 }

--- a/test/mock_provider.hpp
+++ b/test/mock_provider.hpp
@@ -117,9 +117,8 @@ namespace wsrep
             {
                 ++group_seqno_;
                 wsrep::gtid gtid(group_id_, wsrep::seqno(group_seqno_));
-                ws_meta = wsrep::ws_meta(gtid, stid,
-                                         wsrep::seqno(group_seqno_ - 1),
-                                         flags);
+                ws_meta = wsrep::ws_meta(
+                    gtid, stid, wsrep::seqno(group_seqno_ - 1), flags);
                 return wsrep::provider::success;
             }
             else
@@ -135,9 +134,8 @@ namespace wsrep
                 {
                     ++group_seqno_;
                     wsrep::gtid gtid(group_id_, wsrep::seqno(group_seqno_));
-                    ws_meta = wsrep::ws_meta(gtid, stid,
-                                             wsrep::seqno(group_seqno_ - 1),
-                                             flags);
+                    ws_meta = wsrep::ws_meta(
+                        gtid, stid, wsrep::seqno(group_seqno_ - 1), flags);
                     ret = wsrep::provider::error_bf_abort;
                 }
                 bf_abort_map_.erase(it);
@@ -215,8 +213,8 @@ namespace wsrep
                         wsrep::gtid(group_id_, wsrep::seqno(group_seqno_)),
                         wsrep::stid(server_id_, tc.id(), cc.id()),
                         wsrep::seqno(group_seqno_ - 1),
-                        wsrep::provider::flag::start_transaction |
-                        wsrep::provider::flag::commit);
+                        wsrep::provider::flag::start_transaction
+                            | wsrep::provider::flag::commit);
                 }
                 else
                 {
@@ -245,12 +243,10 @@ namespace wsrep
         {
             ++group_seqno_;
             wsrep::gtid gtid(group_id_, wsrep::seqno(group_seqno_));
-            wsrep::stid stid(server_id_,
-                             wsrep::transaction_id::undefined(),
+            wsrep::stid stid(server_id_, wsrep::transaction_id::undefined(),
                              client_id);
             toi_meta = wsrep::ws_meta(gtid, stid,
-                                      wsrep::seqno(group_seqno_ - 1),
-                                      flags);
+                                      wsrep::seqno(group_seqno_ - 1), flags);
             ++toi_write_sets_;
             if (flags & wsrep::provider::flag::start_transaction)
                 ++toi_start_transaction_;
@@ -260,6 +256,7 @@ namespace wsrep
         }
 
         enum wsrep::provider::status leave_toi(wsrep::client_id,
+                                               const wsrep::ws_meta&,
                                                const wsrep::mutable_buffer&)
             WSREP_OVERRIDE
         { return wsrep::provider::success; }
@@ -315,6 +312,7 @@ namespace wsrep
         enum wsrep::provider::status
         bf_abort(wsrep::seqno bf_seqno,
                  wsrep::transaction_id trx_id,
+                 wsrep::client_service&,
                  wsrep::seqno& victim_seqno)
             WSREP_OVERRIDE
         {

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -41,11 +41,12 @@ void wsrep_test::bf_abort_in_total_order(wsrep::client_state& cc)
 }
 // BF abort method to abort transactions via provider
 void wsrep_test::bf_abort_provider(wsrep::mock_server_state& sc,
-                                   const wsrep::transaction& tc,
+                                   const wsrep::client_state& victim_cs,
                                    wsrep::seqno bf_seqno)
 {
     wsrep::seqno victim_seqno;
-    sc.provider().bf_abort(bf_seqno, tc.id(), victim_seqno);
+    sc.provider().bf_abort(bf_seqno, victim_cs.transaction().id(), victim_cs.client_service(),
+                           victim_seqno);
     (void)victim_seqno;
 }
 
@@ -63,13 +64,10 @@ void wsrep_test::terminate_streaming_applier(
     mc.before_command();
     wsrep::mock_high_priority_service hps(sc, &mc, false);
     wsrep::ws_handle ws_handle(transaction_id, (void*)(1));
-    wsrep::ws_meta ws_meta(wsrep::gtid(wsrep::id("cluster1"),
-                                       wsrep::seqno(100)),
-                           wsrep::stid(server_id,
-                                       transaction_id,
-                                       wsrep::client_id(1)),
-                           wsrep::seqno(0),
-                           wsrep::provider::flag::rollback);
+    wsrep::ws_meta ws_meta(
+        wsrep::gtid(wsrep::id("cluster1"), wsrep::seqno(100)),
+        wsrep::stid(server_id, transaction_id, wsrep::client_id(1)),
+        wsrep::seqno(0), wsrep::provider::flag::rollback);
     wsrep::const_buffer data(0, 0);
     sc.on_apply(hps, ws_handle, ws_meta, data);
 }

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -41,7 +41,7 @@ namespace wsrep_test
 
     // BF abort method to abort transactions via provider
     void bf_abort_provider(wsrep::mock_server_state& sc,
-                           const wsrep::transaction& tc,
+                           const wsrep::client_state& victim_cs,
                            wsrep::seqno bf_seqno);
 
     // BF abort in total order

--- a/test/transaction_test.cpp
+++ b/test/transaction_test.cpp
@@ -188,7 +188,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    wsrep_test::bf_abort_provider(sc, tc, wsrep::seqno::undefined());
+    wsrep_test::bf_abort_provider(sc, cc, wsrep::seqno::undefined());
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());
@@ -454,7 +454,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE(tc.id() == wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
 
-    wsrep_test::bf_abort_provider(sc, tc, wsrep::seqno(1));
+    wsrep_test::bf_abort_provider(sc, cc, wsrep::seqno(1));
 
     // Run before commit
     BOOST_REQUIRE(cc.before_commit());

--- a/test/transaction_test_2pc.cpp
+++ b/test/transaction_test_2pc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2019 Codership Oy <info@codership.com>
+ * Copyright (C) 2018-2021 Codership Oy <info@codership.com>
  *
  * This file is part of wsrep-lib.
  *
@@ -22,8 +22,7 @@
 //
 // Test a succesful 2PC transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_2pc,
-                        replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc, replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -52,9 +51,8 @@ BOOST_FIXTURE_TEST_CASE(transaction_2pc,
 //
 // Test a 2PC transaction which gets BF aborted before before_prepare
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_before_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_before_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -69,7 +67,7 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborting);
     BOOST_REQUIRE(cc.after_rollback() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_aborted);
-    BOOST_REQUIRE(cc.after_statement() );
+    BOOST_REQUIRE(cc.after_statement());
     BOOST_REQUIRE(tc.active() == false);
     BOOST_REQUIRE(tc.ordered() == false);
     BOOST_REQUIRE(tc.certified() == false);
@@ -79,9 +77,8 @@ BOOST_FIXTURE_TEST_CASE(
 //
 // Test a 2PC transaction which gets BF aborted before before_prepare
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_after_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_after_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -110,9 +107,8 @@ BOOST_FIXTURE_TEST_CASE(
 // Test a 2PC transaction which gets BF aborted after_prepare() and
 // the rollback takes place before entering before_commit().
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_after_after_prepare,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_after_after_prepare,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -139,9 +135,8 @@ BOOST_FIXTURE_TEST_CASE(
 // Test a 2PC transaction which gets BF aborted between after_prepare()
 // and before_commit()
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_before_before_commit,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_before_before_commit,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -168,14 +163,12 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
 
-
 //
 // Test a 2PC transaction which gets BF aborted when trying to grab
 // commit order.
 //
-BOOST_FIXTURE_TEST_CASE(
-    transaction_2pc_bf_during_commit_order_enter,
-    replicating_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_bf_during_commit_order_enter,
+                        replicating_client_fixture_2pc)
 {
     cc.start_transaction(wsrep::transaction_id(1));
     BOOST_REQUIRE(tc.active());
@@ -183,7 +176,8 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_executing);
     BOOST_REQUIRE(cc.before_prepare() == 0);
     BOOST_REQUIRE(cc.after_prepare() == 0);
-    sc.provider().commit_order_enter_result_ = wsrep::provider::error_bf_abort;
+    sc.provider().commit_order_enter_result_
+        = wsrep::provider::error_bf_abort;
     BOOST_REQUIRE(cc.before_commit());
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_must_replay);
     BOOST_REQUIRE(cc.will_replay_called() == true);
@@ -204,7 +198,6 @@ BOOST_FIXTURE_TEST_CASE(
 ///////////////////////////////////////////////////////////////////////////////
 //                       STREAMING REPLICATION                               //
 ///////////////////////////////////////////////////////////////////////////////
-
 
 BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit,
                         streaming_client_fixture_row)
@@ -251,8 +244,9 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_commit_two_statements,
 // internally. This will cause the transaction to leave before_prepare()
 // in aborted state.
 //
-BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_bf_abort_during_fragment_removal,
-                        streaming_client_fixture_row)
+BOOST_FIXTURE_TEST_CASE(
+    transaction_streaming_2pc_bf_abort_during_fragment_removal,
+    streaming_client_fixture_row)
 {
     BOOST_REQUIRE(cc.start_transaction(wsrep::transaction_id(1)) == 0);
     BOOST_REQUIRE(cc.after_row() == 0);
@@ -270,8 +264,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_streaming_2pc_bf_abort_during_fragment_remov
 //                              APPLYING                                     //
 ///////////////////////////////////////////////////////////////////////////////
 
-BOOST_FIXTURE_TEST_CASE(transaction_2pc_applying,
-                        applying_client_fixture_2pc)
+BOOST_FIXTURE_TEST_CASE(transaction_2pc_applying, applying_client_fixture_2pc)
 {
     BOOST_REQUIRE(cc.before_prepare() == 0);
     BOOST_REQUIRE(tc.state() == wsrep::transaction::s_preparing);

--- a/test/transaction_test_xa.cpp
+++ b/test/transaction_test_xa.cpp
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2019-2025 Codership Oy <info@codership.com>
+ *
+ * This file is part of wsrep-lib.
+ *
+ * Wsrep-lib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Wsrep-lib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wsrep-lib.  If not, see <https://www.gnu.org/licenses/>.
+ */
 #include "client_state_fixture.hpp"
 #include <iostream>
 
 //
 // Test a successful XA transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa,
-                        replicating_client_fixture_sync_rm)
+BOOST_FIXTURE_TEST_CASE(transaction_xa, replicating_client_fixture_sync_rm)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 
@@ -46,7 +63,6 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa,
     BOOST_REQUIRE(tc.certified() == false);
     BOOST_REQUIRE(cc.current_error() == wsrep::e_success);
 }
-
 
 //
 // Test detaching of XA transactions
@@ -118,7 +134,6 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_detach_rollback_by_xid,
     sc.stop_streaming_applier(sc.id(), wsrep::transaction_id(1));
     server_service.release_high_priority_service(hps);
 }
-
 
 //
 // Test XA replay
@@ -214,8 +229,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_replay_after_command_after_result,
 //
 // Test a successful XA transaction lifecycle (applying side)
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
-                        applying_client_fixture)
+BOOST_FIXTURE_TEST_CASE(transaction_xa_applying, applying_client_fixture)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 
@@ -249,8 +263,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_xa_applying,
 //
 // Test a successful XA transaction lifecycle
 //
-BOOST_FIXTURE_TEST_CASE(transaction_xa_sr,
-                        streaming_client_fixture_byte)
+BOOST_FIXTURE_TEST_CASE(transaction_xa_sr, streaming_client_fixture_byte)
 {
     wsrep::xid xid(1, 9, 0, "test xid");
 


### PR DESCRIPTION
- Add a set_provider_factory() method to server_state to allow
  injecting provider factory which will be called when the
  provider is loaded.

Other related changes:
- Implement to_string() helper method for id class.
- Fix id ostream operator human readable id printing.
- Pass victim client_service as an argument to provider::bf_abort()
  to allow passing victim context to custom provider.
- Implement prev() helper method for seqno class.
- Make server_state recover_streaming_appliers_if_not_recovered()
  public. In some recovery scenarios the method must be called outside
  of server_state internal code paths.
- Add storage_service requires_globals() method. The storage service
  implementation may override this to return false if changing to
  storage service context does not require store/reset globals.
- Change view final() to also require that the view status is not
  primary for the view to be final. Also change the method name to
  is_final() to avoid confusion with C++ final identifier.
- Fixes to server state handling in disconnecting and disconnected
  states.
- Keep TOI meta data over whole TOI critical section.
