### PR TITLE
Use ubuntu-22.04 for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,35 +13,35 @@ jobs:
       matrix:
         config:
           # GCC/G++
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "7"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "7"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "8"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "8"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "9"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "9"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "10"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: gcc
             version: "10"
             type: Release
@@ -78,35 +78,35 @@ jobs:
             version: "14"
             type: Release
           # Clang
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "6.0"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "6.0"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "10"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "10"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "11"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "11"
             type: Release
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "12"
             type: Debug
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             CC: clang
             version: "12"
             type: Release


### PR DESCRIPTION
Ubuntu-20.04 hosted runner image is closing down.
