### PR TITLE
Update cmake minimum version range for build with cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Codership Oy <info@codership.com>
 #
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8...4.0)
 
 # Parse version from version header file and store it into
 # WSREP_LIB_VERSION.


### PR DESCRIPTION
compatibility for cmake < 3.5 was removed in cmake 4.0. Adding version range to make it build with cmake 4.0