### PR TITLE
Allow provider initialization even when connection monitor service

### DIFF
--- a/src/connection_monitor_service_v1.cpp
+++ b/src/connection_monitor_service_v1.cpp
@@ -100,7 +100,6 @@ int wsrep::connection_monitor_service_v1_probe(void* dlh)
         wsrep_impl::service_probe<deinit_fn>(
             dlh, WSREP_CONNECTION_MONITOR_SERVICE_DEINIT_FUNC_V1, "connection monitor service v1"))
     {
-        wsrep::log_warning() << "Provider does not support connection monitor service v1";
         return 1;
     }
 

--- a/src/service_helpers.hpp
+++ b/src/service_helpers.hpp
@@ -43,7 +43,7 @@ namespace wsrep_impl
         }
         else
         {
-            wsrep::log_warning() << "Support for " << service_name
+            wsrep::log_info()    << "Support for " << service_name
                                  << " " << symbol
                                  << " not found from provider: "
                                  << dlerror();

--- a/src/wsrep_provider_v26.cpp
+++ b/src/wsrep_provider_v26.cpp
@@ -748,9 +748,13 @@ void wsrep::wsrep_provider_v26::init_services(
     {
         if (init_connection_monitor_service(wsrep_->dlh, services.connection_monitor_service))
         {
-            throw wsrep::runtime_error("Failed to initialize connection monitor service");
+            wsrep::log_info() << "Provider does not support connection monitor service";
+            // provider does not support connection monitoring
         }
-        services_enabled_.connection_monitor_service = services.connection_monitor_service;
+        else
+        {
+            services_enabled_.connection_monitor_service = services.connection_monitor_service;
+        }
     }
 }
 


### PR DESCRIPTION
is not supported by Galera library.