### PR TITLE
MGL-204 Assertion `!conflict_seqno.is_undefined()' failed in Wsrep_write_set::update_conflict() during bf_abort()

### DIFF
--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1141,6 +1141,27 @@ void wsrep::transaction::clone_for_replay(const wsrep::transaction& other)
     ws_handle_ = other.ws_handle_;
     ws_meta_ = other.ws_meta_;
     streaming_context_ = other.streaming_context_;
+
+    /* If ws_meta has undefined seqno but there are certified streaming
+     * fragments, use the last fragment seqno. This happens when a
+     * streaming XA COMMIT is BF aborted before or during certification:
+     * commit_or_rollback_by_xid() uses a local ws_meta for certify(),
+     * so the transaction's ws_meta_ never gets the certified seqno.
+     * The replay thread needs a valid seqno for BF abort ordering.
+     */
+    if (ws_meta_.seqno().is_undefined() &&
+        is_streaming() && !streaming_context_.fragments().empty())
+    {   
+        wsrep::seqno last_frag_seqno(streaming_context_.fragments().back());
+        ws_meta_ = wsrep::ws_meta(
+            wsrep::gtid(ws_meta_.group_id(), last_frag_seqno),
+            wsrep::stid(ws_meta_.server_id(),
+                        ws_meta_.transaction_id(),
+                        ws_meta_.client_id()),
+            ws_meta_.depends_on(),
+            ws_meta_.flags());
+    }
+
     state_ = s_replaying;
     client_service_.notify_state_change();
 }


### PR DESCRIPTION
Issue:
When a streaming XA transaction COMMIT is BF-aborted and later replayed via commit_or_rollback_by_xid(), the replay transaction cloned from the original THD had an undefined ws_meta_.seqno(). This happened because commit_or_rollback_by_xid() certifies using a local ws_meta instance, so the transaction’s ws_meta_ never receives the certified seqno.

During replay, if the streaming applier encounters an InnoDB lock conflict and performs a BF abort on a local transaction, the BF abort path calls wsrep_thd_trx_seqno() for the replaying THD. With the undefined seqno this eventually triggers:

  Wsrep_write_set::update_conflict():
    assert(!conflict_seqno.is_undefined());

Solution:
Fix by enhancing wsrep::transaction::clone_for_replay(): when cloning a streaming transaction for replay, if ws_meta_.seqno() is undefined but the streaming_context has stored fragments, use the last fragment’s seqno to reconstruct ws_meta_. This ensures the replay THD always has a valid seqno for conflict ordering during BF aborts.

The testcase in [mgl_187_conflict_seqno.patch](https://github.com/user-attachments/files/26605447/mgl_187_conflict_seqno.patch) fails on
branch: mgl-11.8-enterprise-CRAFT
commit: 88c1805fabf76ddd465b3920f5e5bca4db67d6b3
