### PR TITLE
MGL-187: Test galera_sr.galera_xa_concurrent fails occasionally with Raft

### DIFF
--- a/include/wsrep/high_priority_service.hpp
+++ b/include/wsrep/high_priority_service.hpp
@@ -235,9 +235,41 @@ namespace wsrep
          */
         virtual void debug_crash(const char* crash_point) = 0;
 
+        /**
+         * serialize concurrent applier threads operating on the
+         * same streaming-applier (SA).  apply_serial_lock()/unlock() are
+         * called by server_state.cpp around the apply_write_set() call in
+         * apply_fragment/commit_fragment so the SA's owning_thread_id_
+         * tracking and per-SA THD state mutations cannot race between two
+         * applier threads handling consecutive fragments of the same SR
+         * transaction.
+         */
+        virtual void apply_serial_lock() {}
+        virtual void apply_serial_unlock() {}
+
     protected:
         wsrep::server_state& server_state_;
         bool must_exit_;
+    };
+
+    /**
+     * guard for apply_serial_lock/unlock. Used in
+     * server_state.cpp::apply_fragment and commit_fragment to bracket the
+     * SA's apply_write_set call.
+     */
+    class apply_serial_lock_guard
+    {
+    public:
+        apply_serial_lock_guard(high_priority_service& service)
+            : service_(service)
+        {
+            service_.apply_serial_lock();
+        }
+        ~apply_serial_lock_guard() { service_.apply_serial_unlock(); }
+    private:
+        apply_serial_lock_guard(const apply_serial_lock_guard&);
+        apply_serial_lock_guard& operator=(const apply_serial_lock_guard&);
+        high_priority_service& service_;
     };
 
     class high_priority_switch

--- a/src/client_state.cpp
+++ b/src/client_state.cpp
@@ -489,7 +489,12 @@ void wsrep::client_state::disable_streaming()
 
 void wsrep::client_state::xa_detach()
 {
-    assert(mode_ == m_local);
+    /*
+      streaming-applier (m_high_priority) THDs reach this path via
+      slave_applier_reset_xa_trans() -> wsrep_xa_detach() when applying an
+      XA PREPARE writeset on a follower.
+    */
+    assert(mode_ == m_local || mode_ == m_high_priority);
     assert(state_ == s_none || state_ == s_exec || state_ == s_quitting);
     transaction_.xa_detach();
 }

--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -93,7 +93,19 @@ static int apply_fragment(wsrep::server_state& server_state,
     int ret(0);
     int apply_err;
     wsrep::mutable_buffer err;
+    wsrep::xid xid;
     {
+        /*
+          serialize concurrent applier threads on the same SA.
+          The lock wraps the high_priority_switch lifetime so the switch's
+          store_globals() (which sets SA's owning_thread_id_) cannot
+          interleave between two appliers and confuse assertions like
+          client_state::before_prepare's `owning_thread_id_ == this_thread`.
+          Released before the OUTER append_fragment_and_commit (below) to
+          avoid a deadlock with group-commit ordering: that commit can
+          wait for prior writesets, and those may need this lock too.
+        */
+        wsrep::apply_serial_lock_guard apply_lock(*streaming_applier);
         wsrep::high_priority_switch sw(high_priority_service,
                                        *streaming_applier);
         apply_err = streaming_applier->apply_write_set(ws_meta, data, err);
@@ -101,6 +113,13 @@ static int apply_fragment(wsrep::server_state& server_state,
         {
             assert(err.size() == 0);
             streaming_applier->after_apply();
+            /*
+              Snapshot xid under the lock; the SA's transaction state can be
+              mutated by the next applier thread once the lock is released,
+              so reading xid from the unlocked append_fragment_and_commit
+              path below would race.
+            */
+            xid = streaming_applier->transaction().xid();
         }
         else
         {
@@ -131,7 +150,6 @@ static int apply_fragment(wsrep::server_state& server_state,
         if (!apply_err)
         {
             high_priority_service.debug_crash("crash_apply_cb_before_append_frag");
-            const wsrep::xid xid(streaming_applier->transaction().xid());
             ret = high_priority_service.append_fragment_and_commit(
                 ws_handle, ws_meta, data, xid);
             high_priority_service.debug_crash("crash_apply_cb_after_append_frag");
@@ -159,6 +177,8 @@ static int commit_fragment(wsrep::server_state& server_state,
 {
     int ret(0);
     {
+        /* serialize SA apply */
+        wsrep::apply_serial_lock_guard apply_lock(*streaming_applier);
         wsrep::high_priority_switch sw(
             high_priority_service, *streaming_applier);
         wsrep::mutable_buffer err;
@@ -233,6 +253,8 @@ static int rollback_fragment(wsrep::server_state& server_state,
     // be removed manually.
     wsrep::const_buffer no_error;
     {
+        // serialize SA rollback
+        wsrep::apply_serial_lock_guard apply_lock(*streaming_applier);
         wsrep::high_priority_switch ws(
             high_priority_service, *streaming_applier);
         // Streaming applier rolls back out of order. Fragment

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1253,19 +1253,45 @@ void wsrep::transaction::xa_detach()
     debug_log_state("xa_detach enter");
     assert(state() == s_prepared ||
            client_state_.state() == wsrep::client_state::s_quitting);
+    const bool is_high_priority(
+        client_state_.mode() == wsrep::client_state::m_high_priority);
     if (state() == s_prepared)
     {
-        wsrep::server_state& server_state(client_state_.server_state());
-        server_state.convert_streaming_client_to_applier(&client_state_);
-        client_service_.store_globals();
-        client_service_.cleanup_transaction();
+        /*
+          convert_streaming_client_to_applier() looks up the
+          client_state in server_state.streaming_clients_ which only
+          contains local (m_local) clients that originated the SR
+          transaction. When xa_detach is called from a streaming-applier
+          (m_high_priority), the applier's client_state is not in that map;
+          skip the convert path.
+        */
+        if (!is_high_priority)
+        {
+            wsrep::server_state& server_state(client_state_.server_state());
+            server_state.convert_streaming_client_to_applier(&client_state_);
+            client_service_.store_globals();
+            client_service_.cleanup_transaction();
+        }
     }
     wsrep::unique_lock<wsrep::mutex> lock(client_state_.mutex_);
     streaming_context_.cleanup();
-    state(lock, s_aborting);
-    state(lock, s_aborted);
-    provider().release(ws_handle_);
-    cleanup();
+    if (!is_high_priority)
+    {
+        /*
+          For m_high_priority (streaming-applier on a follower)
+          leave state at s_prepared and skip provider().release/cleanup() so
+          commit_fragment in server_state.cpp skips remove_fragments (the
+          `trx.state() != s_prepared` check) and the matching XA
+          COMMIT/ROLLBACK applier still finds the SA in streaming_appliers_
+          map by its transaction id. The server-side SR-detached path uses
+          ha_commit_or_rollback_by_xid + xid_cache_delete via m_xa_xid /
+          m_is_sr_xa_detached on the SA.
+        */
+        state(lock, s_aborting);
+        state(lock, s_aborted);
+        provider().release(ws_handle_);
+        cleanup();
+    }
     debug_log_state("xa_detach leave");
 }
 


### PR DESCRIPTION
Issue:
1. slave_applier_reset_xa_trans() calls wsrep_xa_detach() on the streaming-applier (SA) THD after XA PREPARE.  client_state::xa_detach() asserted mode_ == m_local, and transaction::xa_detach() called convert_streaming_client_to_applier() which looks up the SA in streaming_clients_ -- SAs are never added there (only m_local originators are), so the lookup asserts.  The SA must also stay in s_prepared and remain in streaming_appliers_ so the matching XA COMMIT/ROLLBACK applies via the server-side SR-detached path (ha_commit_or_rollback_by_xid on the saved XID).

2. Two applier threads can construct high_priority_switch on the same SA concurrently; each calls store_globals() which mutates the SA's client_state owning_thread_id_.  The later update mid-flight trips before_prepare's owning_thread_id_ == this_thread on the earlier thread.  depends_on serializes fragment ordering but not the SA hand-off window at the wsrep-lib level.

Solution:
1. client_state::xa_detach(): allow m_high_priority in addition to m_local.  transaction::xa_detach(): for m_high_priority skip convert_streaming_client_to_applier and the s_aborting/s_aborted transitions, provider.release(), and cleanup() -- SA stays in s_prepared with id_ set.

2. Add virtual apply_serial_lock()/unlock() on high_priority_service (no-op default) and wrap the high_priority_switch lifetime with these calls in apply_fragment, commit_fragment and rollback_fragment. Released before the outer append_fragment_and_commit() to avoid group-commit deadlock.  Server overrides with a per-SA mysql_mutex_t; different SAs use different mutexes so SR-level parallelism is preserved.