### PR TITLE
MDEV-38843: WSREP: BF applier failed on a node causing complete Cluster lockup

### DIFF
--- a/src/server_state.cpp
+++ b/src/server_state.cpp
@@ -336,7 +336,14 @@ static int apply_write_set(wsrep::server_state& server_state,
             {
                 assert(err.size() == 0);
                 ret = high_priority_service.commit(ws_handle, ws_meta);
-                ret = ret || (high_priority_service.after_apply(), 0);
+                // Commit may fail if commit order could not be entered, e.g.
+                // the node left the primary component. Roll back the
+                // still-active applier transaction; after_apply() cleans up.
+                if (ret)
+                {
+                    high_priority_service.rollback(ws_handle, ws_meta);
+                }
+                high_priority_service.after_apply();
             }
             else
             {


### PR DESCRIPTION
Issue:
After losing an inconsistency vote the node leaves the primary component and an applier can be torn down while its transaction is still active (its commit failed, so after_apply() cleanup was skipped). client_state::close() then calls transaction::after_statement() on it, but after_statement() implements local-client semantics and asserts client_state_.mode() == m_local, aborting the server in debug builds.

Solution:
In close(), route high priority (non-local) transactions through the applier cleanup path after_applying() instead of after_statement().