### PR TITLE
MDEV-39710: Update git modules WSREP Links to mariadb-corporation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wsrep-API/v26"]
 	path = wsrep-API/v26
-	url = https://github.com/codership/wsrep-API.git
+	url = https://github.com/mariadb-corporation/wsrep-API.git


### PR DESCRIPTION
The .gitmodules file uses the old Codership Github repo link. This redirects to the mariadb-corporation repo, so it isn't a functional problem, but it should still be updated to the correct repo.